### PR TITLE
Change distribution format to not be a universal package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
 [wheel]
-universal = 1
 
 [flake8]
 exclude = docs


### PR DESCRIPTION
For now, we're not planning on supporting python2 so we shouldn't declare this package as universal.