### PR TITLE
Small fixes for status endpoint

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -154,7 +154,7 @@ class TransactionsEndpoint(NamespacedDriver):
             txid (str): Id of the transaction to retrieve the status for.
 
         Returns:
-            dict: The transaction with the given id.
+            dict: A dict containing a 'status' item for the transaction.
 
         """
         path = self.path + txid + '/status'

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -137,3 +137,9 @@ class TestTransactionsEndpoint:
         sleep(1.2)
         status = driver.transactions.status(txid)
         assert status['status'] == 'valid'
+
+    def test_status_not_found(self, driver):
+        from bigchaindb_driver.exceptions import NotFoundError
+        txid = 'dummy_id'
+        with raises(NotFoundError):
+            driver.transactions.status(txid)


### PR DESCRIPTION
Adds a small test for retrieving statuses of unfound transactions and fixes up documentation for the function.