### PR TITLE
Add sanity checks to given keypairs during driver initialization

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -37,8 +37,8 @@ class BigchainDB:
                  transport_class=Transport):
         """Initialize a :class:`~bigchaindb_driver.BigchainDB` driver instance.
 
-        If a :attr:`verifying_key` and :attr:`signing_key` are given, this
-        instance will be bound to the given keypair and be applied as defaults
+        If a :attr:`verifying_key` or :attr:`signing_key` are given, this
+        instance will be bound to the keys and applied them as defaults
         whenever a verifying and/or signing key are needed.
 
         Args:
@@ -50,28 +50,10 @@ class BigchainDB:
                 key for the ED25519 curve to bind this driver with.
             signing_key (str, keyword, optional): the base58 encoded private
                 key for the ED25519 curve to bind this driver with.
-                Must be given with :attr:`verifying_key`.
             transport_class (Transport, keyword, optional): Transport class to
                 use.
                 Defaults to :class:`~bigchaindb_driver.transport.Transport`.
-
-        Raises:
-            :class:`~bigchaindb_driver.exceptions.InvalidVerifyingKey: if the
-                given :attr:`verifying_key` was not valid, or a
-                :attr:`signing_key` was given without a :attr:`verifying_key`
-            :class:`~bigchaindb_driver.exceptions.InvalidSigningKey: if the
-                given :attr:`signing_key` was not valid
         """
-        if verifying_key is not None and not isinstance(verifying_key, str):
-                raise InvalidVerifyingKey("'verifying_key' must be a string")
-
-        if signing_key is not None:
-            if not isinstance(signing_key, str):
-                raise InvalidSigningKey("'signing_key must be a string")
-            if verifying_key is None:
-                raise InvalidVerifyingKey(("'verifying_key' must be given if"
-                                           "'signing_key' is given"))
-
         self.nodes = nodes if nodes else (DEFAULT_NODE,)
         self.transport = transport_class(*nodes)
 

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -37,19 +37,41 @@ class BigchainDB:
                  transport_class=Transport):
         """Initialize a :class:`~bigchaindb_driver.BigchainDB` driver instance.
 
-        Args:
-            *nodes: BigchainDB nodes to connect to. Currently, the full URL
-                must be given In the absence of any node, the default of the
-                :attr:`transport_class` will be used, e.g.:
-                ``'http://localhost:9984/api/v1'``.
-            verifying_key (str): the base58 encoded public key for the ED25519
-                curve.
-            signing_key (str): the base58 encoded private key for the ED25519
-                curve.
-            transport_class: Transport class to use. Defaults to
-                :class:`~bigchaindb_driver.transport.Transport`.
+        If a :attr:`verifying_key` and :attr:`signing_key` are given, this
+        instance will be bound to the given keypair and be applied as defaults
+        whenever a verifying and/or signing key are needed.
 
+        Args:
+            *nodes (str): BigchainDB nodes to connect to. Currently, the full
+                URL must be given. In the absence of any node, the default of
+                the :attr:`transport_class` will be used, e.g.:
+                ``'http://localhost:9984/api/v1'``.
+            verifying_key (str, keyword, optional): the base58 encoded public
+                key for the ED25519 curve to bind this driver with.
+            signing_key (str, keyword, optional): the base58 encoded private
+                key for the ED25519 curve to bind this driver with.
+                Must be given with :attr:`verifying_key`.
+            transport_class (Transport, keyword, optional): Transport class to
+                use.
+                Defaults to :class:`~bigchaindb_driver.transport.Transport`.
+
+        Raises:
+            :class:`~bigchaindb_driver.exceptions.InvalidVerifyingKey: if the
+                given :attr:`verifying_key` was not valid, or a
+                :attr:`signing_key` was given without a :attr:`verifying_key`
+            :class:`~bigchaindb_driver.exceptions.InvalidSigningKey: if the
+                given :attr:`signing_key` was not valid
         """
+        if verifying_key is not None and not isinstance(verifying_key, str):
+                raise InvalidVerifyingKey("'verifying_key' must be a string")
+
+        if signing_key is not None:
+            if not isinstance(signing_key, str):
+                raise InvalidSigningKey("'signing_key must be a string")
+            if verifying_key is None:
+                raise InvalidVerifyingKey(("'verifying_key' must be given if"
+                                           "'signing_key' is given"))
+
         self.nodes = nodes if nodes else (DEFAULT_NODE,)
         self.transport = transport_class(*nodes)
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -16,11 +16,41 @@ def test_temp_driver_returns_a_temp_driver(bdb_node):
     assert driver.nodes[0] == bdb_node
 
 
+def test_driver_init_basic(bdb_node):
+    from bigchaindb_driver.driver import BigchainDB
+    driver = BigchainDB(bdb_node)
+    assert driver.verifying_key is None
+    assert driver.signing_key is None
+    assert driver.nodes[0] == bdb_node
+    assert driver.transactions
+
+
 def test_driver_init_without_nodes(alice_keypair):
     from bigchaindb_driver.driver import BigchainDB, DEFAULT_NODE
-    bdb = BigchainDB(verifying_key=alice_keypair.vk,
-                     signing_key=alice_keypair.sk)
-    assert bdb.nodes == (DEFAULT_NODE,)
+    driver = BigchainDB(verifying_key=alice_keypair.vk,
+                        signing_key=alice_keypair.sk)
+    assert driver.nodes == (DEFAULT_NODE,)
+
+
+def test_driver_raises_with_bad_keys(alice_keypair):
+    from bigchaindb_driver.driver import BigchainDB
+    from bigchaindb_driver.exceptions import (
+        InvalidSigningKey,
+        InvalidVerifyingKey,
+    )
+
+    with raises(InvalidVerifyingKey):
+        BigchainDB(verifying_key=0, signing_key=alice_keypair.sk)
+    with raises(InvalidSigningKey):
+        BigchainDB(verifying_key=alice_keypair.vk, signing_key=0)
+
+    # A verifying key is necessary when binding a signing_key
+    with raises(InvalidVerifyingKey):
+        BigchainDB(signing_key=alice_keypair.sk)
+    # But not the other way around
+    driver = BigchainDB(verifying_key=alice_keypair.vk)
+    assert driver.verifying_key == alice_keypair.vk
+    assert driver.signing_key is None
 
 
 class TestTransactionsEndpoint:

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -32,27 +32,6 @@ def test_driver_init_without_nodes(alice_keypair):
     assert driver.nodes == (DEFAULT_NODE,)
 
 
-def test_driver_raises_with_bad_keys(alice_keypair):
-    from bigchaindb_driver.driver import BigchainDB
-    from bigchaindb_driver.exceptions import (
-        InvalidSigningKey,
-        InvalidVerifyingKey,
-    )
-
-    with raises(InvalidVerifyingKey):
-        BigchainDB(verifying_key=0, signing_key=alice_keypair.sk)
-    with raises(InvalidSigningKey):
-        BigchainDB(verifying_key=alice_keypair.vk, signing_key=0)
-
-    # A verifying key is necessary when binding a signing_key
-    with raises(InvalidVerifyingKey):
-        BigchainDB(signing_key=alice_keypair.sk)
-    # But not the other way around
-    driver = BigchainDB(verifying_key=alice_keypair.vk)
-    assert driver.verifying_key == alice_keypair.vk
-    assert driver.signing_key is None
-
-
 class TestTransactionsEndpoint:
 
     @mark.skip(reason='transaction model not ready; see bigchaindb/issues/342')


### PR DESCRIPTION
Some small sanity checks for making sure the keys are strings and that if a signing key is given, a verifying key is also given.

Not sure if it'll ever be useful to only give a signing key, but I imagine the other way around (only binding a verifying key to the driver) may be useful for people to only supply their signing key when absolutely necessary.