### PR TITLE
Revert "Rename BigchaindbException to DriverException"

### DIFF
--- a/bigchaindb_driver/exceptions.py
+++ b/bigchaindb_driver/exceptions.py
@@ -1,24 +1,24 @@
 """Exceptions used by :mod:`bigchaindb_driver`."""
 
 
-class DriverException(Exception):
-    """Base exception for all BigchainDB driver exceptions."""
+class BigchaindbException(Exception):
+    """Base exception for all Bigchaindb exceptions."""
 
 
-class KeypairNotFoundException(DriverException):
+class KeypairNotFoundException(BigchaindbException):
     """Raised if an operation cannot proceed because the keypair was not given.
     """
 
 
-class InvalidSigningKey(DriverException):
+class InvalidSigningKey(BigchaindbException):
     """Raised if a signing key is invalid. E.g.: :obj:`None`."""
 
 
-class InvalidVerifyingKey(DriverException):
+class InvalidVerifyingKey(BigchaindbException):
     """Raised if a verifying key is invalid. E.g.: :obj:`None`."""
 
 
-class TransportError(DriverException):
+class TransportError(BigchaindbException):
     """Base exception for transport related errors.
 
     This is mainly for cases where the status code denotes an HTTP error, and

--- a/docs/libref.rst
+++ b/docs/libref.rst
@@ -71,7 +71,7 @@ Library Reference
 
 .. automodule:: bigchaindb_driver.exceptions
 
-.. autoclass:: DriverException
+.. autoclass:: BigchaindbException
 
 .. autoclass:: TransportError
 


### PR DESCRIPTION
Reverts commit 9c4f5fa77f27349cb141fbd1578c331ab6bd91d0.

As @sbellem [points out](https://github.com/bigchaindb/bigchaindb-driver/pull/64#issuecomment-246295605), this can be confusing when using multiple
drivers and having a fully named exception is common practice.