### PR TITLE
Keep test dependencies on BigchainDB's master branch

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -84,7 +84,7 @@ development.
     $ docker-compose run --rm driver flake8 bigchaindb_driver tests
 
 7 To run the tests::
-    
+
     $ docker-compose run --rm driver py.test -v
 
 8.. Commit your changes and push your branch to GitHub::
@@ -111,6 +111,17 @@ Before you submit a pull request, check that it meets these guidelines:
 Tips
 ----
 
+Dependency on Bigchaindb
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the `BigchainDB server Dockerfile <https://github.com/bigchaindb/bigchaindb-driver/blob/master/compose/server/Dockerfile>`_
+and `.travis.yml <https://github.com/bigchaindb/bigchaindb-driver/blob/master/.travis.yml>`_
+are set to depend from BigchainDB's master branch to more easily track changes
+against BigchainDB's API.
+
+Tests
+~~~~~
+
 To run a subset of tests::
 
     $ docker-compose run --rm driver py.test -v tests/test_driver.py
@@ -118,6 +129,6 @@ To run a subset of tests::
 .. important:: When running tests, unless you are targeting a test that does
     not require a connection with the BigchainDB server, you need to run the
     BigchainDB and RethinkDB servers::
-    
+
     $ docker-compose up -d rethinkdb
     $ docker-compose up -d server

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -114,7 +114,7 @@ Tips
 Dependency on Bigchaindb
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, the `BigchainDB server Dockerfile <https://github.com/bigchaindb/bigchaindb-driver/blob/master/compose/server/Dockerfile>`_
+By default, the development requirements, `BigchainDB server Dockerfile <https://github.com/bigchaindb/bigchaindb-driver/blob/master/compose/server/Dockerfile>`_,
 and `.travis.yml <https://github.com/bigchaindb/bigchaindb-driver/blob/master/.travis.yml>`_
 are set to depend from BigchainDB's master branch to more easily track changes
 against BigchainDB's API.

--- a/compose/server/Dockerfile
+++ b/compose/server/Dockerfile
@@ -9,6 +9,5 @@ RUN pip install --upgrade pip
 
 COPY . /usr/src/app/
 
-# Until https://github.com/bigchaindb/bigchaindb/issues/559 is solved
 RUN pip install "git+https://github.com/bigchaindb/bigchaindb.git"
 RUN bigchaindb -y configure

--- a/dependency_links.txt
+++ b/dependency_links.txt
@@ -1,1 +1,3 @@
 --process-dependency-links
+
+git+https://github.com/bigchaindb/bigchaindb#egg=bigchaindb


### PR DESCRIPTION
Otherwise we'll have to remember to change the dependency each time we need to work on upstream API changes from BigchainDB.

On the fence about this though; maybe we should be pegging the BigchainDB versions we test against on release as specific driver versions are made to work for specific versions of  BigchainDB?