### PR TITLE
Fixed links to bigchaindb/bigchaindb-driver repo on GitHub

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,13 +30,13 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/bigchaindb/bigchaindb_driver
+    $ git clone git://github.com/bigchaindb/bigchaindb-driver
 
 Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl  -OL https://github.com/bigchaindb/bigchaindb_driver/tarball/master
+    $ curl  -OL https://github.com/bigchaindb/bigchaindb-driver/tarball/master
 
 Once you have a copy of the source, you can install it with:
 
@@ -45,5 +45,5 @@ Once you have a copy of the source, you can install it with:
     $ python setup.py install
 
 
-.. _Github repo: https://github.com/bigchaindb/bigchaindb_driver
-.. _tarball: https://github.com/bigchaindb/bigchaindb_driver/tarball/master
+.. _Github repo: https://github.com/bigchaindb/bigchaindb-driver
+.. _tarball: https://github.com/bigchaindb/bigchaindb-driver/tarball/master

--- a/travis_pypi_setup.py
+++ b/travis_pypi_setup.py
@@ -21,7 +21,7 @@ except:
     from urllib.request import urlopen
 
 
-GITHUB_REPO = 'bigchaindb/bigchaindb_driver'
+GITHUB_REPO = 'bigchaindb/bigchaindb-driver'
 TRAVIS_CONFIG_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), '.travis.yml')
 


### PR DESCRIPTION
On Gitter, @gabrielmendanha noted that some of the links to the bigchaindb/bigchaindb-driver repo were broken in the page about Installation. Correct links have the form:

...github.com/bigchaindb/bigchaindb-driver...

but in the page about Installation, they had the form:

...github.com/bigchaindb/bigchaindb_driver...

with an underscore instead of a dash. I changed the underscore `_` to a dash `-`.

@sbellem I'm not as sure about the change I made in `travis_pypi_setup.py`. Can you take a look?