### PR TITLE
Moved all installation-related docs to that page and expanded it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,26 +20,8 @@ BigchainDB Python Driver
      :alt: Updates
 
 
-Python driver for BigchainDB
-
-* Development Status: Pre-Alpha
 * Free software: Apache Software License 2.0
 * Documentation: https://docs.bigchaindb.com/projects/py-driver/
-
-Important
----------
-Since the BigchainDB driver is under development, and may rapidly change, we  
-recommend installing the latest version:
-
-.. code-block:: bash
-
-    pip install --upgrade bigchaindb_driver
-
-Lastly, BigchainDB (server and driver) depend on `cryptoconditions`_, which now
-uses `PyNaCl`_ (`Networking and Cryptography library`_) which depends on
-``ffi.h``. Hence, depending on your setup you may need to install the
-development files for ``libffi``. Please see
-`How to Install OS-Level Dependencies <https://docs.bigchaindb.com/projects/server/en/latest/appendices/install-os-level-deps.html#how-to-install-os-level-dependencies>`_.
 
 
 Features
@@ -48,10 +30,11 @@ Features
 * Minimal support for `CREATE`, `TRANSFER`, and `GET` operations on the
   `/transactions` endpoint.
 
+
 Credits
 -------
 
-This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypackage`_ project template.
+This package was initially created using Cookiecutter_ and the `audreyr/cookiecutter-pypackage`_ project template. Many BigchainDB developers have contributed since then.
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,49 +1,86 @@
-.. highlight:: shell
-
 ============
 Installation
 ============
 
+Prerequisites
+-------------
 
-Development release
--------------------
+OS-Level Prerequisites
+^^^^^^^^^^^^^^^^^^^^^^
 
-To install bigchaindb-driver, run this very simple command in your terminal:
-
-.. code-block:: console
-
-    $ pip install bigchaindb_driver
-
-If you don't have `pip`_ installed, this `Python installation guide`_ can guide
-you through the process.
-
-.. _pip: https://pip.pypa.io
-.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
+BigchainDB (server and driver) depends on `cryptoconditions`_, which now
+uses `PyNaCl`_ (`Networking and Cryptography library`_), which depends on
+``ffi.h``. Hence, depending on your setup, you may need to install the
+development files for ``libffi``. Please see
+`How to Install OS-Level Dependencies <https://docs.bigchaindb.com/projects/server/en/latest/appendices/install-os-level-deps.html#how-to-install-os-level-dependencies>`_.
 
 
-From sources
-------------
+Python 3
+^^^^^^^^
 
-The sources for bigchaindb-driver can be downloaded from the `Github repo`_.
+The BigchainDB Python Driver uses Python 3, preferably a recent version. You can check your version of Python using:
 
+.. code-block:: bash
+
+    python --version
+
+An easy way to install a specific version of Python, and to switch between versions of Python, is to use `virtualenv <https://virtualenv.pypa.io/en/latest/>`_. Another option is `conda <http://conda.pydata.org/docs/>`_.
+
+
+pip
+^^^
+
+You also need to get a recent version of ``pip``, the Python package manager. See the `BigchainDB Server docs about how to do that <https://docs.bigchaindb.com/projects/server/en/latest/appendices/install-latest-pip.html>`_.
+
+
+Installing the BigchainDB Python Driver
+---------------------------------------
+
+Here we cover two ways to install the BigchainDB Python Driver: you can download and install the latest ``bigchaindb_driver`` package from PyPI (the Python Package Index) or you can dowload the latest source code from GitHub, and install that.
+
+
+Installing from PyPI
+^^^^^^^^^^^^^^^^^^^^
+
+You can use ``pip``:
+
+.. code-block:: bash
+
+    pip install bigchaindb_driver
+
+Since the BigchainDB Python Driver is under development, and may change rapidly, we  
+recommend upgrading to the latest version from time to time:
+
+.. code-block:: bash
+
+    pip install --upgrade bigchaindb_driver
+
+
+Installing from the Source Code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The source code for the BigchainDB Python Driver can be downloaded from the `Github repo`_.
 You can either clone the public repository:
 
-.. code-block:: console
+.. code-block:: bash
 
-    $ git clone git://github.com/bigchaindb/bigchaindb-driver
+    git clone git://github.com/bigchaindb/bigchaindb-driver
 
 Or download the `tarball`_:
 
-.. code-block:: console
+.. code-block:: bash
 
-    $ curl  -OL https://github.com/bigchaindb/bigchaindb-driver/tarball/master
+    curl  -OL https://github.com/bigchaindb/bigchaindb-driver/tarball/master
 
-Once you have a copy of the source, you can install it with:
+Once you have a copy of the source code, you can install it with:
 
-.. code-block:: console
+.. code-block:: bash
 
-    $ python setup.py install
+    python setup.py install
 
 
 .. _Github repo: https://github.com/bigchaindb/bigchaindb-driver
 .. _tarball: https://github.com/bigchaindb/bigchaindb-driver/tarball/master
+.. _pynacl: https://github.com/pyca/pynacl/
+.. _Networking and Cryptography library: https://nacl.cr.yp.to/
+.. _cryptoconditions: https://github.com/bigchaindb/cryptoconditions


### PR DESCRIPTION
* Moved all the installation-related docs to the **Installation** page.
* Expanded the **Installation** page by documenting how to install all the prerequisites (OS-level, Python 3, and pip).