### PR TITLE
Remove user provided transaction timestamp [untested]

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -110,7 +110,6 @@ bigchain:
         'owners_before': ['F5K2n1xnqoyCBiX2PaqjRrLiF6KsBaFzyVLE9WrySFKg']}],
       'metadata': None,
       'operation': 'CREATE',
-      'timestamp': '1477661142'},
      'version': 1}
 
 
@@ -195,7 +194,6 @@ The ``transfer_tx`` dictionary should look something like:
         'owners_before': ['F5K2n1xnqoyCBiX2PaqjRrLiF6KsBaFzyVLE9WrySFKg']}],
       'metadata': None,
       'operation': 'TRANSFER',
-      'timestamp': '1477661596'},
      'version': 1}
 
 Notice, ``bob``'s verifying key (public key), appearing in the above ``dict``.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -146,7 +146,6 @@ The ``creation_tx`` dictionary should be similar to:
         'owners_before': ['3EnDZNgf9Ss7cEdiPaSJ8NZDbVjRE5aXG1UT9aoE7kRj']}],
       'metadata': None,
       'operation': 'CREATE',
-      'timestamp': '1476809307'},
      'version': 1}
 
 
@@ -205,7 +204,6 @@ The ``transfer_tx`` dictionary should look something like:
         'owners_before': ['3EnDZNgf9Ss7cEdiPaSJ8NZDbVjRE5aXG1UT9aoE7kRj']}],
       'metadata': None,
       'operation': 'TRANSFER',
-      'timestamp': '1476809389'},
      'version': 1}
 
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -41,7 +41,6 @@ class TestTransactionsEndpoint:
         assert tx['transaction']['asset']['id']
         assert tx['transaction']['asset']['refillable'] is False
         assert tx['transaction']['asset']['updatable'] is False
-        assert tx['transaction']['timestamp']
         fulfillment = tx['transaction']['fulfillments'][0]
         condition = tx['transaction']['conditions'][0]
         assert fulfillment['owners_before'][0] == alice_driver.verifying_key
@@ -58,7 +57,6 @@ class TestTransactionsEndpoint:
         assert tx['version']
         assert tx['transaction']['operation'] == 'CREATE'
         assert tx['transaction']['asset']['data'] is None
-        assert tx['transaction']['timestamp']
         fulfillment = tx['transaction']['fulfillments'][0]
         condition = tx['transaction']['conditions'][0]
         assert fulfillment['owners_before'][0] == bob_pubkey


### PR DESCRIPTION
A PR to remove user provided timestamp from tests and docuementation.

This has not been tested since I got some errors running `docker-compose run --rm bdb-driver pytest -v`, about (E: Failed to fetch http://deb.debian.org/debian/pool/main/g/gpm/libgpm2_1.20.4-6.1+b2_amd64.deb  Could not resolve 'deb.debian.org').