### PR TITLE
Properly set default connection node if none given

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -45,7 +45,7 @@ class BigchainDB:
         self._nodes = nodes if nodes else (DEFAULT_NODE,)
         self._verifying_key = verifying_key
         self._signing_key = signing_key
-        self._transport = transport_class(*self.nodes)
+        self._transport = transport_class(*self._nodes)
         self._transactions = TransactionsEndpoint(self)
 
     @property

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -45,7 +45,7 @@ class BigchainDB:
         self._nodes = nodes if nodes else (DEFAULT_NODE,)
         self._verifying_key = verifying_key
         self._signing_key = signing_key
-        self._transport = transport_class(*nodes)
+        self._transport = transport_class(*self.nodes)
         self._transactions = TransactionsEndpoint(self)
 
     @property

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: rethinkdb
     ports:
       - "58585:8080"
-      - "28015"
+      - "28015:28015"
   bdb-server:
     build: ./compose/server
     environment:
@@ -25,5 +25,5 @@ services:
       BIGCHAINDB_API_ENDPOINT: http://bdb-server:9984/api/v1
       BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
     ports:
-      - "9984"
+      - "32675:9984"
     command: bigchaindb start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: rethinkdb
     ports:
       - "58585:8080"
-      - "28015:28015"
+      - "28015"
   bdb-server:
     build: ./compose/server
     environment:
@@ -25,5 +25,5 @@ services:
       BIGCHAINDB_API_ENDPOINT: http://bdb-server:9984/api/v1
       BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
     ports:
-      - "32675:9984"
+      - "9984"
     command: bigchaindb start

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -16,6 +16,7 @@ def test_driver_init_basic(bdb_node):
     assert driver.verifying_key is None
     assert driver.signing_key is None
     assert driver.nodes[0] == bdb_node
+    assert driver.transport.nodes == driver.nodes
     assert driver.transactions
 
 
@@ -24,6 +25,7 @@ def test_driver_init_without_nodes(alice_keypair):
     driver = BigchainDB(verifying_key=alice_keypair.vk,
                         signing_key=alice_keypair.sk)
     assert driver.nodes == (DEFAULT_NODE,)
+    assert driver.transport.nodes == (DEFAULT_NODE,)
 
 
 class TestTransactionsEndpoint:


### PR DESCRIPTION
Oops, turns out we didn't actually use the default node.