### PR TITLE
Revert "Refine flexible support for owners_after"

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -100,13 +100,9 @@ class TransactionsEndpoint(NamespacedDriver):
                 One or more public keys representing the issuer(s) of
                 the asset being created. Only applies for ``'CREATE'``
                 operations. Defaults to ``None``.
-            owners_after (:obj:`str` | :obj:`tuple` | :obj:`dict`, optional):
+            owners_after (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
                 One or more public keys representing the new owner(s) of the
                 asset being created or transferred. Defaults to ``None``.
-                For divisible assets one may pass a dictionary of public
-                keys mapping to the amount. A dictionary key is expected
-                to be a string (one public key) or a tuple of public
-                keys. The amount is expected to be an integer.
             asset (:obj:`dict`, optional): The asset being created or
                 transferred. MUST be supplied for ``'TRANSFER'`` operations.
                 Defaults to ``None``.

--- a/bigchaindb_driver/utils.py
+++ b/bigchaindb_driver/utils.py
@@ -6,12 +6,7 @@ Attributes:
         :class:`~.CreateOperation`.
 
 """
-import collections
-from functools import singledispatch
-
 from bigchaindb.common.transaction import Asset
-
-from .exceptions import BigchaindbException
 
 
 class CreateOperation:
@@ -96,31 +91,3 @@ def _normalize_asset(asset, is_transfer=False):
             if not asset:
                 asset = None
     return asset
-
-
-@singledispatch
-def _normalize_owners_after(owners_after):
-    raise BigchaindbException(
-        'Unsupported type for owners_after: {}.'
-        'owners_after must be a string, a dict, or an iterable such as'
-        'a list, tuple or a set.'.format(owners_after)
-    )
-
-
-@_normalize_owners_after.register(str)
-def _normalize_owners_after_str(owners_after):
-    return [([owners_after], 1)]
-
-
-@_normalize_owners_after.register(dict)
-def _normalize_owners_after_dict(owners_after):
-    owners_amounts = []
-    for owner, amount in owners_after.items():
-        owner = list(owner) if isinstance(owner, tuple) else [owner]
-        owners_amounts.append((owner, amount))
-    return owners_amounts
-
-
-@_normalize_owners_after.register(collections.abc.Iterable)
-def _normalize_owners_after_iterable(owners_after):
-    return [([owner for owner in owners_after], 1)]

--- a/tests/test_offchain.py
+++ b/tests/test_offchain.py
@@ -51,7 +51,7 @@ def test_prepare_create_transaction_default(alice_pubkey):
 @mark.parametrize('owners_after', (
     '2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',
     ('2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',),
-    {'2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS': 1},
+    [(['2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS'], 1)],
 ))
 def test_prepare_create_transaction(asset, owners_before, owners_after):
     from bigchaindb_driver.offchain import prepare_create_transaction
@@ -69,38 +69,9 @@ def test_prepare_create_transaction(asset, owners_before, owners_after):
 
 
 @mark.parametrize('owners_after', (
-    None,
     '2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',
     ('2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',),
-    ('2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',
-     'G7J7bXF8cqSrjrxUKwcF8tCriEKC5CgyPHmtGwUi4BK3'),
-    {'2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS': 1},
-    {('2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',
-     'G7J7bXF8cqSrjrxUKwcF8tCriEKC5CgyPHmtGwUi4BK3'): 1},
-))
-def test_owners_after_prepare_create_transaction(alice_pubkey, owners_after):
-    from bigchaindb_driver.offchain import prepare_create_transaction
-    create_transaction = prepare_create_transaction(
-        owners_before=alice_pubkey, owners_after=owners_after)
-    assert 'id' in create_transaction
-    assert 'transaction' in create_transaction
-    assert 'version' in create_transaction
-    assert 'asset' in create_transaction['transaction']
-    assert 'conditions' in create_transaction['transaction']
-    assert 'fulfillments' in create_transaction['transaction']
-    assert 'metadata' in create_transaction['transaction']
-    assert 'operation' in create_transaction['transaction']
-    assert create_transaction['transaction']['operation'] == 'CREATE'
-
-
-@mark.parametrize('owners_after', (
-    '2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',
-    ('2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',),
-    ('2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',
-     'G7J7bXF8cqSrjrxUKwcF8tCriEKC5CgyPHmtGwUi4BK3'),
-    {'2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS': 1},
-    {('2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',
-     'G7J7bXF8cqSrjrxUKwcF8tCriEKC5CgyPHmtGwUi4BK3'): 1},
+    [(['2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS'], 1)],
 ))
 def test_prepare_transfer_transaction(alice_transaction, owners_after):
     from bigchaindb_driver.offchain import prepare_transfer_transaction
@@ -126,14 +97,6 @@ def test_prepare_transfer_transaction(alice_transaction, owners_after):
     assert 'metadata' in transfer_transaction['transaction']
     assert 'operation' in transfer_transaction['transaction']
     assert transfer_transaction['transaction']['operation'] == 'TRANSFER'
-
-
-def test_prepare_transfer_transaction_raises(alice_transaction):
-    from bigchaindb_driver.offchain import prepare_transfer_transaction
-    from bigchaindb_driver.exceptions import BigchaindbException
-    with raises(BigchaindbException):
-        prepare_transfer_transaction(
-            inputs={}, owners_after=None, asset=None)
 
 
 @mark.parametrize('alice_sk', (


### PR DESCRIPTION
Reverts bigchaindb/bigchaindb-driver#168

Overlooked multi key dict case, e.g.:

```python
owners_after=[([carly.verifying_key], 5), ([carly.verifying_key], 5)]
```