### PR TITLE
Add hacking file and doc section

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,0 +1,15 @@
+Installing latest master with pip
+---------------------------------
+In order to work with the latest BigchainDB (server) master branch:
+
+.. code-block:: bash
+
+    $ pip install --process-dependency-links git+https://github.com/bigchaindb/bigchaindb-driver.git
+
+Point to some BigchainDB node, which is running BigchainDB server ``master``:
+
+.. code-block:: python
+
+    from bigchaindb_driver import BigchainDB 
+    
+    bdb = BigchainDB('http://here.be.dragons:9984/api/v1') 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include CHANGELOG.rst
 include LICENSE
+include HACKING.rst 
 include README.rst
 
 recursive-include tests *

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ BigchainDB Python Driver
    aboutthedocs
    contributing
    authors
-   changelog 
+   changelog
 
 Indices and tables
 ==================

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -114,6 +114,9 @@ Once you have a copy of the source code, you can install it by going to the dire
     python setup.py install
 
 
+.. include:: ../HACKING.rst
+
+
 .. _Github repo: https://github.com/bigchaindb/bigchaindb-driver
 .. _tarball: https://github.com/bigchaindb/bigchaindb-driver/tarball/master
 .. _pynacl: https://github.com/pyca/pynacl/


### PR DESCRIPTION
Due to the current dependency on bigchaindb server code, when the master branch is needed installing with pip requires using the flag `--process-dependency-links`, which may be unknown to many users. The added docs aim to provide the possibly missing information.