### PR TITLE
Remove master:master mapping in compatibility matrix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,6 @@ Compatibility Matrix
 +=======================+=======================+
 | ``0.8.x``             | ``0.1.x``             |
 +-----------------------+-----------------------+
-| ``master``            | ``master``            |
-+-----------------------+-----------------------+
 
 `Although we do our best to keep the master branches in sync, there may be
 occasional delays.`


### PR DESCRIPTION
Arguments for removing it:

- We don't have tests confirming the compatibility for every change that lands
  in master of both bigchaindb/bigchaindb and bigchaindb/bigchaindb-driver
- It involves a lot of effort to check whether or not master and master are
  compatible
- We shouldn't check manually (if we want to have this mapping, lets
  automate it)
- There has already been a case where users got confused:
  https://gitter.im/bigchaindb/bigchaindb?at=5846b0abf666c5a138d91959