### PR TITLE
Revert "Bump version: 0.1.2 → 0.1.3"

### DIFF
--- a/bigchaindb_driver/__init__.py
+++ b/bigchaindb_driver/__init__.py
@@ -3,4 +3,4 @@ from .driver import BigchainDB   # noqa
 
 __author__ = 'BigchainDB'
 __email__ = 'dev@bigchaindb.com'
-__version__ = '0.1.3'
+__version__ = '0.1.2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ docs_require = [
 
 setup(
     name='bigchaindb_driver',
-    version='0.1.3',
+    version='0.1.2',
     description="Python driver for BigchainDB",
     long_description=readme + '\n\n' + changelog,
     author="BigchainDB",


### PR DESCRIPTION
Reverts bigchaindb/bigchaindb-driver#191 -- docs are broken