### PR TITLE
Fix driver interfaces for tx model changes in 0.9

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -96,7 +96,7 @@ class TransactionsEndpoint(NamespacedDriver):
     path = '/transactions/'
 
     @staticmethod
-    def prepare(*, operation='CREATE', tx_signers=None,
+    def prepare(*, operation='CREATE', signers=None,
                 recipients=None, asset=None, metadata=None, inputs=None):
         """
         Prepares a transaction payload, ready to be fulfilled.
@@ -104,7 +104,7 @@ class TransactionsEndpoint(NamespacedDriver):
         Args:
             operation (str): The operation to perform. Must be ``'CREATE'``
                 or ``'TRANSFER'``. Case insensitive. Defaults to ``'CREATE'``.
-            tx_signers (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
+            signers (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
                 One or more public keys representing the issuer(s) of
                 the asset being created. Only applies for ``'CREATE'``
                 operations. Defaults to ``None``.
@@ -133,25 +133,25 @@ class TransactionsEndpoint(NamespacedDriver):
 
             **CREATE operations**
 
-            * ``tx_signers`` MUST be set.
+            * ``signers`` MUST be set.
             * ``recipients``, ``asset``, and ``metadata`` MAY be set.
             * The argument ``inputs`` is ignored.
             * If ``recipients`` is not given, or evaluates to
-              ``False``, it will be set equal to ``tx_signers``::
+              ``False``, it will be set equal to ``signers``::
 
                 if not recipients:
-                    recipients = tx_signers
+                    recipients = signers
 
             **TRANSFER operations**
 
             * ``recipients``, ``asset``, and ``inputs`` MUST be set.
             * ``metadata`` MAY be set.
-            * The argument ``tx_signers`` is ignored.
+            * The argument ``signers`` is ignored.
 
         """
         return prepare_transaction(
             operation=operation,
-            tx_signers=tx_signers,
+            signers=signers,
             recipients=recipients,
             asset=asset,
             metadata=metadata,

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -109,8 +109,9 @@ class TransactionsEndpoint(NamespacedDriver):
                 the asset being created. Only applies for ``'CREATE'``
                 operations. Defaults to ``None``.
             recipients (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
-                One or more public keys representing the new owner(s) of the
-                asset being created or transferred. Defaults to ``None``.
+                One or more public keys representing the new recipients(s)
+                of the asset being created or transferred.
+                Defaults to ``None``.
             asset (:obj:`dict`, optional): The asset being created or
                 transferred. MUST be supplied for ``'TRANSFER'`` operations.
                 Defaults to ``None``.

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -96,19 +96,19 @@ class TransactionsEndpoint(NamespacedDriver):
     path = '/transactions/'
 
     @staticmethod
-    def prepare(*, operation='CREATE', owners_before=None,
-                owners_after=None, asset=None, metadata=None, inputs=None):
+    def prepare(*, operation='CREATE', tx_signers=None,
+                recipients=None, asset=None, metadata=None, inputs=None):
         """
         Prepares a transaction payload, ready to be fulfilled.
 
         Args:
             operation (str): The operation to perform. Must be ``'CREATE'``
                 or ``'TRANSFER'``. Case insensitive. Defaults to ``'CREATE'``.
-            owners_before (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
+            tx_signers (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
                 One or more public keys representing the issuer(s) of
                 the asset being created. Only applies for ``'CREATE'``
                 operations. Defaults to ``None``.
-            owners_after (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
+            recipients (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
                 One or more public keys representing the new owner(s) of the
                 asset being created or transferred. Defaults to ``None``.
             asset (:obj:`dict`, optional): The asset being created or
@@ -133,26 +133,26 @@ class TransactionsEndpoint(NamespacedDriver):
 
             **CREATE operations**
 
-            * ``owners_before`` MUST be set.
-            * ``owners_after``, ``asset``, and ``metadata`` MAY be set.
+            * ``tx_signers`` MUST be set.
+            * ``recipients``, ``asset``, and ``metadata`` MAY be set.
             * The argument ``inputs`` is ignored.
-            * If ``owners_after`` is not given, or evaluates to
-              ``False``, it will be set equal to ``owners_before``::
+            * If ``recipients`` is not given, or evaluates to
+              ``False``, it will be set equal to ``tx_signers``::
 
-                if not owners_after:
-                    owners_after = owners_before
+                if not recipients:
+                    recipients = tx_signers
 
             **TRANSFER operations**
 
-            * ``owners_after``, ``asset``, and ``inputs`` MUST be set.
+            * ``recipients``, ``asset``, and ``inputs`` MUST be set.
             * ``metadata`` MAY be set.
-            * The argument ``owners_before`` is ignored.
+            * The argument ``tx_signers`` is ignored.
 
         """
         return prepare_transaction(
             operation=operation,
-            owners_before=owners_before,
-            owners_after=owners_after,
+            tx_signers=tx_signers,
+            recipients=recipients,
             asset=asset,
             metadata=metadata,
             inputs=inputs,

--- a/bigchaindb_driver/offchain.py
+++ b/bigchaindb_driver/offchain.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 @singledispatch
 def _prepare_transaction(operation,
-                         tx_signers=None,
+                         signers=None,
                          recipients=None,
                          asset=None,
                          metadata=None,
@@ -44,11 +44,11 @@ def _prepare_create_transaction_dispatcher(operation, **kwargs):
 
 @_prepare_transaction.register(TransferOperation)
 def _prepare_transfer_transaction_dispatcher(operation, **kwargs):
-    del kwargs['tx_signers']
+    del kwargs['signers']
     return prepare_transfer_transaction(**kwargs)
 
 
-def prepare_transaction(*, operation='CREATE', tx_signers=None,
+def prepare_transaction(*, operation='CREATE', signers=None,
                         recipients=None, asset=None, metadata=None,
                         inputs=None):
     """
@@ -60,7 +60,7 @@ def prepare_transaction(*, operation='CREATE', tx_signers=None,
     Args:
         operation (str): The operation to perform. Must be ``'CREATE'``
             or ``'TRANSFER'``. Case insensitive. Defaults to ``'CREATE'``.
-        tx_signers (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
+        signers (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
             One or more public keys representing the issuer(s) of the
             asset being created. Only applies for ``'CREATE'``
             operations. Defaults to ``None``.
@@ -89,26 +89,26 @@ def prepare_transaction(*, operation='CREATE', tx_signers=None,
 
         **CREATE operations**
 
-        * ``tx_signers`` MUST be set.
+        * ``signers`` MUST be set.
         * ``recipients``, ``asset``, and ``metadata`` MAY be set.
         * The argument ``inputs`` is ignored.
         * If ``recipients`` is not given, or evaluates to
-          ``False``, it will be set equal to ``tx_signers``::
+          ``False``, it will be set equal to ``signers``::
 
             if not recipients:
-                recipients = tx_signers
+                recipients = signers
 
         **TRANSFER operations**
 
         * ``recipients``, ``asset``, and ``inputs`` MUST be set.
         * ``metadata`` MAY be set.
-        * The argument ``tx_signers`` is ignored.
+        * The argument ``signers`` is ignored.
 
     """
     operation = _normalize_operation(operation)
     return _prepare_transaction(
         operation,
-        tx_signers=tx_signers,
+        signers=signers,
         recipients=recipients,
         asset=asset,
         metadata=metadata,
@@ -117,7 +117,7 @@ def prepare_transaction(*, operation='CREATE', tx_signers=None,
 
 
 def prepare_create_transaction(*,
-                               tx_signers,
+                               signers,
                                recipients=None,
                                asset=None,
                                metadata=None):
@@ -126,7 +126,7 @@ def prepare_create_transaction(*,
     fulfilled.
 
     Args:
-        tx_signers (:obj:`list` | :obj:`tuple` | :obj:`str`): One
+        signers (:obj:`list` | :obj:`tuple` | :obj:`str`): One
             or more public keys representing the issuer(s) of the asset
             being created.
         recipients (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
@@ -141,21 +141,21 @@ def prepare_create_transaction(*,
         dict: The prepared ``"CREATE"`` transaction.
 
     .. important:: If ``recipients`` is not given, or evaluates to
-        ``False``, it will be set equal to ``tx_signers``::
+        ``False``, it will be set equal to ``signers``::
 
             if not recipients:
-                recipients = tx_signers
+                recipients = signers
 
     """
-    if not isinstance(tx_signers, (list, tuple)):
-        tx_signers = [tx_signers]
+    if not isinstance(signers, (list, tuple)):
+        signers = [signers]
     # NOTE: Needed for the time being. See
     # https://github.com/bigchaindb/bigchaindb/issues/797
-    elif isinstance(tx_signers, tuple):
-        tx_signers = list(tx_signers)
+    elif isinstance(signers, tuple):
+        signers = list(signers)
 
     if not recipients:
-        recipients = [(tx_signers, 1)]
+        recipients = [(signers, 1)]
     elif not isinstance(recipients, (list, tuple)):
             recipients = [([recipients], 1)]
     # NOTE: Needed for the time being. See
@@ -164,7 +164,7 @@ def prepare_create_transaction(*,
         recipients = [(list(recipients), 1)]
 
     transaction = Transaction.create(
-        tx_signers,
+        signers,
         recipients,
         metadata=metadata,
         asset=asset,

--- a/bigchaindb_driver/offchain.py
+++ b/bigchaindb_driver/offchain.py
@@ -130,8 +130,8 @@ def prepare_create_transaction(*,
             or more public keys representing the issuer(s) of the asset
             being created.
         recipients (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
-            One or more public keys representing the new owner(s) of the
-            asset being created. Defaults to ``None``.
+            One or more public keys representing the new recipients(s)
+            of the asset being created. Defaults to ``None``.
         asset (:obj:`dict`, optional): The data associated with the
             asset being created with this transaction. Defaults to ``None``.
         metadata (:obj:`dict`, optional): Metadata associated with the
@@ -187,8 +187,8 @@ def prepare_transfer_transaction(*,
             intends to fulfill. Each input is expected to be a
             :obj:`dict`.
         recipients (:obj:`str` | :obj:`list` | :obj:`tuple`): One or
-            more public keys representing the new owner(s) of the asset
-            being transferred.
+            more public keys representing the new recipients(s) of the
+            asset being transferred.
         asset (:obj:`dict`): The asset being transferred with this
             transaction.
         metadata (:obj:`dict`): Metadata associated with the

--- a/bigchaindb_driver/offchain.py
+++ b/bigchaindb_driver/offchain.py
@@ -7,7 +7,7 @@ import logging
 from functools import singledispatch
 
 from bigchaindb.common.transaction import (
-    Fulfillment as BdbFulfillment,
+    Input,
     Transaction,
     TransactionLink,
 )
@@ -18,7 +18,6 @@ from .exceptions import BigchaindbException, MissingSigningKeyError
 from .utils import (
     CreateOperation,
     TransferOperation,
-    _normalize_asset,
     _normalize_operation,
 )
 
@@ -27,8 +26,8 @@ logger = logging.getLogger(__name__)
 
 @singledispatch
 def _prepare_transaction(operation,
-                         owners_before=None,
-                         owners_after=None,
+                         tx_signers=None,
+                         recipients=None,
                          asset=None,
                          metadata=None,
                          inputs=None):
@@ -45,12 +44,12 @@ def _prepare_create_transaction_dispatcher(operation, **kwargs):
 
 @_prepare_transaction.register(TransferOperation)
 def _prepare_transfer_transaction_dispatcher(operation, **kwargs):
-    del kwargs['owners_before']
+    del kwargs['tx_signers']
     return prepare_transfer_transaction(**kwargs)
 
 
-def prepare_transaction(*, operation='CREATE', owners_before=None,
-                        owners_after=None, asset=None, metadata=None,
+def prepare_transaction(*, operation='CREATE', tx_signers=None,
+                        recipients=None, asset=None, metadata=None,
                         inputs=None):
     """
     Prepares a transaction payload, ready to be fulfilled. Depending on
@@ -61,11 +60,11 @@ def prepare_transaction(*, operation='CREATE', owners_before=None,
     Args:
         operation (str): The operation to perform. Must be ``'CREATE'``
             or ``'TRANSFER'``. Case insensitive. Defaults to ``'CREATE'``.
-        owners_before (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
+        tx_signers (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
             One or more public keys representing the issuer(s) of the
             asset being created. Only applies for ``'CREATE'``
             operations. Defaults to ``None``.
-        owners_after (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
+        recipients (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
             One or more public keys representing the new owner(s) of the
             asset being created or transferred. Defaults to ``None``.
         asset (:obj:`dict`, optional): The asset being created or
@@ -90,27 +89,27 @@ def prepare_transaction(*, operation='CREATE', owners_before=None,
 
         **CREATE operations**
 
-        * ``owners_before`` MUST be set.
-        * ``owners_after``, ``asset``, and ``metadata`` MAY be set.
+        * ``tx_signers`` MUST be set.
+        * ``recipients``, ``asset``, and ``metadata`` MAY be set.
         * The argument ``inputs`` is ignored.
-        * If ``owners_after`` is not given, or evaluates to
-          ``False``, it will be set equal to ``owners_before``::
+        * If ``recipients`` is not given, or evaluates to
+          ``False``, it will be set equal to ``tx_signers``::
 
-            if not owners_after:
-                owners_after = owners_before
+            if not recipients:
+                recipients = tx_signers
 
         **TRANSFER operations**
 
-        * ``owners_after``, ``asset``, and ``inputs`` MUST be set.
+        * ``recipients``, ``asset``, and ``inputs`` MUST be set.
         * ``metadata`` MAY be set.
-        * The argument ``owners_before`` is ignored.
+        * The argument ``tx_signers`` is ignored.
 
     """
     operation = _normalize_operation(operation)
     return _prepare_transaction(
         operation,
-        owners_before=owners_before,
-        owners_after=owners_after,
+        tx_signers=tx_signers,
+        recipients=recipients,
         asset=asset,
         metadata=metadata,
         inputs=inputs,
@@ -118,8 +117,8 @@ def prepare_transaction(*, operation='CREATE', owners_before=None,
 
 
 def prepare_create_transaction(*,
-                               owners_before,
-                               owners_after=None,
+                               tx_signers,
+                               recipients=None,
                                asset=None,
                                metadata=None):
     """
@@ -127,51 +126,46 @@ def prepare_create_transaction(*,
     fulfilled.
 
     Args:
-        owners_before (:obj:`list` | :obj:`tuple` | :obj:`str`): One
+        tx_signers (:obj:`list` | :obj:`tuple` | :obj:`str`): One
             or more public keys representing the issuer(s) of the asset
             being created.
-        owners_after (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
+        recipients (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
             One or more public keys representing the new owner(s) of the
             asset being created. Defaults to ``None``.
-        asset (:obj:`dict`, optional): The asset being created. Defaults
-            to ``None``.
+        asset (:obj:`dict`, optional): The metadata associated with the
+            asset being created with this transaction. Defaults to ``None``.
         metadata (:obj:`dict`, optional): Metadata associated with the
             transaction. Defaults to ``None``.
 
     Returns:
         dict: The prepared ``"CREATE"`` transaction.
 
-    .. important:: If ``owners_after`` is not given, or evaluates to
-        ``False``, it will be set equal to ``owners_before``::
+    .. important:: If ``recipients`` is not given, or evaluates to
+        ``False``, it will be set equal to ``tx_signers``::
 
-            if not owners_after:
-                owners_after = owners_before
+            if not recipients:
+                recipients = tx_signers
 
     """
-    if not isinstance(owners_before, (list, tuple)):
-        owners_before = [owners_before]
+    if not isinstance(tx_signers, (list, tuple)):
+        tx_signers = [tx_signers]
     # NOTE: Needed for the time being. See
     # https://github.com/bigchaindb/bigchaindb/issues/797
-    elif isinstance(owners_before, tuple):
-        owners_before = list(owners_before)
+    elif isinstance(tx_signers, tuple):
+        tx_signers = list(tx_signers)
 
-    # TODO: This will only work for non-divisible. If its a divisible asset
-    # Transaction.create will raise an exception saying that divisible assets
-    # need to have amount > 1.
-    if not owners_after:
-        owners_after = [(owners_before, 1)]
-    elif not isinstance(owners_after, (list, tuple)):
-            owners_after = [([owners_after], 1)]
+    if not recipients:
+        recipients = [(tx_signers, 1)]
+    elif not isinstance(recipients, (list, tuple)):
+            recipients = [([recipients], 1)]
     # NOTE: Needed for the time being. See
     # https://github.com/bigchaindb/bigchaindb/issues/797
-    elif isinstance(owners_after, tuple):
-        owners_after = [(list(owners_after), 1)]
-
-    asset = _normalize_asset(asset)
+    elif isinstance(recipients, tuple):
+        recipients = [(list(recipients), 1)]
 
     transaction = Transaction.create(
-        owners_before,
-        owners_after,
+        tx_signers,
+        recipients,
         metadata=metadata,
         asset=asset,
     )
@@ -180,7 +174,7 @@ def prepare_create_transaction(*,
 
 def prepare_transfer_transaction(*,
                                  inputs,
-                                 owners_after,
+                                 recipients,
                                  asset,
                                  metadata=None):
     """
@@ -192,10 +186,11 @@ def prepare_transfer_transaction(*,
             inputs holding the condition(s) that this transaction
             intends to fulfill. Each input is expected to be a
             :obj:`dict`.
-        owners_after (:obj:`str` | :obj:`list` | :obj:`tuple`): One or
+        recipients (:obj:`str` | :obj:`list` | :obj:`tuple`): One or
             more public keys representing the new owner(s) of the asset
             being transferred.
-        asset (:obj:`dict`): The asset being transferred.
+        asset (:obj:`dict`): The asset being transferred with this
+            transaction.
         metadata (:obj:`dict`): Metadata associated with the
             transaction. Defaults to ``None``.
 
@@ -203,6 +198,9 @@ def prepare_transfer_transaction(*,
         dict: The prepared ``"TRANSFER"`` transaction.
 
     Example:
+
+        .. todo:: Replace this section with docs.
+
         In case it may not be clear what an input should look like, say
         Alice (public key: ``'3Cxh1eKZk3Wp9KGBWFS7iVde465UvqUKnEqTg2MW4wNf'``)
         wishes to transfer an asset over to Bob
@@ -214,10 +212,7 @@ def prepare_transfer_transaction(*,
             >>> tx
             {'id': '57cff2b9490468bdb6d4767a1b07905fdbe18d638d9c7783f639b4b2bc165c39',
              'transaction': {'asset': {'data': {'msg': 'Hello BigchainDB!'},
-               'divisible': False,
-               'id': 'd04b05de-774c-4f81-9e54-6c19ed3cd18d',
-               'refillable': False,
-               'updatable': False},
+               'id': '57cff2b9490468bdb6d4767a1b07905fdbe18d638d9c7783f639b4b2bc165c39'},
               'conditions': [{'amount': 1,
                 'cid': 0,
                 'condition': {'details': {'bitmask': 32,
@@ -267,34 +262,32 @@ def prepare_transfer_transaction(*,
 
         >>> prepare_transfer_transaction(
         ...     inputs=input_,
-        ...     owners_after='EcRawy3Y22eAUSS94vLF8BVJi62wbqbD9iSUSUNU9wAA',
+        ...     recipients='EcRawy3Y22eAUSS94vLF8BVJi62wbqbD9iSUSUNU9wAA',
         ...     asset=tx['transaction']['asset'],
         ... )
 
     """
     if not isinstance(inputs, (list, tuple)):
         inputs = (inputs, )
-    if not isinstance(owners_after, (list, tuple)):
-        owners_after = [([owners_after], 1)]
+    if not isinstance(recipients, (list, tuple)):
+        recipients = [([recipients], 1)]
 
     # NOTE: Needed for the time being. See
     # https://github.com/bigchaindb/bigchaindb/issues/797
-    if isinstance(owners_after, tuple):
-        owners_after = [(list(owners_after), 1)]
+    if isinstance(recipients, tuple):
+        recipients = [(list(recipients), 1)]
 
     fulfillments = [
-        BdbFulfillment(Fulfillment.from_dict(input_['fulfillment']),
-                       input_['owners_before'],
-                       tx_input=TransactionLink(**input_['input']))
+        Input(Fulfillment.from_dict(input_['fulfillment']),
+              input_['owners_before'],
+              fulfills=TransactionLink(**input_['fulfills']))
         for input_ in inputs
     ]
 
-    asset = _normalize_asset(asset, is_transfer=True)
-
     transaction = Transaction.transfer(
         fulfillments,
-        owners_after,
-        asset,
+        recipients,
+        asset_id=asset['id'],
         metadata=metadata,
     )
     return transaction.to_dict()

--- a/bigchaindb_driver/offchain.py
+++ b/bigchaindb_driver/offchain.py
@@ -132,7 +132,7 @@ def prepare_create_transaction(*,
         recipients (:obj:`list` | :obj:`tuple` | :obj:`str`, optional):
             One or more public keys representing the new owner(s) of the
             asset being created. Defaults to ``None``.
-        asset (:obj:`dict`, optional): The metadata associated with the
+        asset (:obj:`dict`, optional): The data associated with the
             asset being created with this transaction. Defaults to ``None``.
         metadata (:obj:`dict`, optional): Metadata associated with the
             transaction. Defaults to ``None``.

--- a/bigchaindb_driver/utils.py
+++ b/bigchaindb_driver/utils.py
@@ -6,7 +6,6 @@ Attributes:
         :class:`~.CreateOperation`.
 
 """
-from bigchaindb.common.transaction import Asset
 
 
 class CreateOperation:
@@ -56,38 +55,3 @@ def _normalize_operation(operation):
         pass
 
     return operation
-
-
-def _normalize_asset(asset, is_transfer=False):
-    """
-    Normalizes the given asset dictionary.
-
-    For now, this means converting the given asset dictionary to a
-    :class:`~.bigchaindb.common.transaction.Asset` class.
-
-    Args:
-        asset (dict): The asset to normalize.
-        is_transfer (boal, optional): Flag used to indicate whether the
-            asset is to be used as part of a `'TRANSFER'` operation or
-            not. Defaults to ``False``.
-
-    Returns:
-        The :class:`~.bigchaindb.common.transaction.Asset` class,
-        instantiated from the given asset dictionary.
-
-        .. important:: If the instantiation step fails, ``None`` may be
-            returned.
-
-    .. danger:: For specific internal usage only. The behavior is tricky,
-        and is subject to change.
-
-    """
-    if is_transfer:
-        asset = Asset.from_dict(asset)
-    else:
-        try:
-            asset = Asset(**asset)
-        except (AttributeError, TypeError):
-            if not asset:
-                asset = None
-    return asset

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,5 +70,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'bigchaindb-server': (
-        'https://docs.bigchaindb.com/projects/server/en/v0.8.0/', None),
+        'https://docs.bigchaindb.com/projects/server/en/latest/', None),
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,7 @@ def persisted_alice_transaction(alice_privkey, driver, alice_transaction_obj):
 
 
 @fixture
-def bicycle_asset_payload():
+def bicycle_data():
     return {
         'bicycle': {
             'manufacturer': 'bkfab',
@@ -180,7 +180,7 @@ def bicycle_asset_payload():
 
 
 @fixture
-def car_asset_payload():
+def car_data():
     return {
         'car': {
             'manufacturer': 'bkfab',
@@ -190,12 +190,12 @@ def car_asset_payload():
 
 
 @fixture
-def prepared_carol_bicycle_transaction(carol_keypair, bicycle_asset_payload):
+def prepared_carol_bicycle_transaction(carol_keypair, bicycle_data):
     condition = make_ed25519_condition(carol_keypair.public_key)
     fulfillment = make_fulfillment(carol_keypair.public_key)
     tx = {
         'asset': {
-            'data': bicycle_asset_payload,
+            'data': bicycle_data,
         },
         'metadata': None,
         'operation': 'CREATE',
@@ -232,12 +232,12 @@ def persisted_carol_bicycle_transaction(driver,
 
 
 @fixture
-def prepared_carol_car_transaction(carol_keypair, car_asset_payload):
+def prepared_carol_car_transaction(carol_keypair, car_data):
     condition = make_ed25519_condition(carol_keypair.public_key)
     fulfillment = make_fulfillment(carol_keypair.public_key)
     tx = {
         'asset': {
-            'data': car_asset_payload,
+            'data': car_data,
         },
         'metadata': None,
         'operation': 'CREATE',

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -60,7 +60,7 @@ class TestTransactionsEndpoint:
             driver.transactions.status(txid)
 
     def test_prepare(self, driver, alice_pubkey):
-        transaction = driver.transactions.prepare(tx_signers=[alice_pubkey])
+        transaction = driver.transactions.prepare(signers=[alice_pubkey])
         assert 'id' in transaction
         assert 'version' in transaction
         assert 'asset' in transaction

--- a/tests/test_offchain.py
+++ b/tests/test_offchain.py
@@ -12,7 +12,7 @@ def test_prepare_transaction(operation, return_value, function, monkeypatch):
     from bigchaindb_driver import offchain
     from bigchaindb_driver.offchain import prepare_transaction
 
-    def mock(tx_signers=None, recipients=None,
+    def mock(signers=None, recipients=None,
              inputs=None, asset=None, metadata=None):
         return return_value
     monkeypatch.setattr(offchain, function, mock)
@@ -28,7 +28,7 @@ def test_prepare_transaction_raises():
 
 def test_prepare_create_transaction_default(alice_pubkey):
     from bigchaindb_driver.offchain import prepare_create_transaction
-    create_transaction = prepare_create_transaction(tx_signers=alice_pubkey)
+    create_transaction = prepare_create_transaction(signers=alice_pubkey)
     assert 'id' in create_transaction
     assert 'version' in create_transaction
     assert 'asset' in create_transaction
@@ -42,7 +42,7 @@ def test_prepare_create_transaction_default(alice_pubkey):
 @mark.parametrize('asset', (
     None, {}, {'data': {'msg': 'Hello BigchainDB!'}},
 ))
-@mark.parametrize('tx_signers', (
+@mark.parametrize('signers', (
     'G7J7bXF8cqSrjrxUKwcF8tCriEKC5CgyPHmtGwUi4BK3',
     ('G7J7bXF8cqSrjrxUKwcF8tCriEKC5CgyPHmtGwUi4BK3',),
     ['G7J7bXF8cqSrjrxUKwcF8tCriEKC5CgyPHmtGwUi4BK3'],
@@ -52,10 +52,10 @@ def test_prepare_create_transaction_default(alice_pubkey):
     ('2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS',),
     [(['2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS'], 1)],
 ))
-def test_prepare_create_transaction(asset, tx_signers, recipients):
+def test_prepare_create_transaction(asset, signers, recipients):
     from bigchaindb_driver.offchain import prepare_create_transaction
     create_transaction = prepare_create_transaction(
-        tx_signers=tx_signers, recipients=recipients, asset=asset)
+        signers=signers, recipients=recipients, asset=asset)
     assert 'id' in create_transaction
     assert 'version' in create_transaction
     assert 'asset' in create_transaction


### PR DESCRIPTION
Fixes #221.

Interface changes from upstream:
* `owners_before` argument was renamed to `tx_signers` (renamed to `signers` for the driver interface)
* `owners_after` argument was renamed to `recipients`
* `Fulfilment` class was renamed to `Input`
* `conditions` in transaction was renamed to `output`
* `fulfillments` in transaction was renamed to `input`

bigchaindb/bigchaindb#1089 details a bug found that causes two tests to fail.