### PR TITLE
Get info of a node and its api root

### DIFF
--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -4,7 +4,8 @@ set -e -x
 
 if [ "${TOXENV}" == "py35" ]; then
     rethinkdb --daemon
-    bigchaindb -y configure rethinkdb
+    export BIGCHAINDB_KEYPAIR_PUBLIC=GW1nrdZm4mbVC8ePeiGWz6DqHexqewqy5teURVHi3RG4
+    export BIGCHAINDB_KEYPAIR_PRIVATE=2kQgBtQnHoauw8QchKM7xYvEBW1QDoHzhBsCL9Vi1AzB 
 
     # Start BigchainDB in the background and ignore any output
     bigchaindb start >/dev/null 2>&1 &

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -12,4 +12,4 @@ Point to some BigchainDB node, which is running BigchainDB server ``master``:
 
     from bigchaindb_driver import BigchainDB 
     
-    bdb = BigchainDB('http://here.be.dragons:9984/api/v1') 
+    bdb = BigchainDB('http://here.be.dragons:9984') 

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -64,6 +64,49 @@ class BigchainDB:
         """
         return self._outputs
 
+    def info(self, headers=None):
+        """Retrieves information of the node being connected to via the
+        root endpoint ``'/'``.
+
+        Args:
+            headers (dict): Optional headers to pass to the request.
+
+        Returns:
+            dict: Details of the node that this instance is connected
+            to. Some information that may be interesting:
+
+                * the server version,
+                * the public key of the node, and
+                * its key ring (list of public keys of the nodes this
+                  node is connected to).
+
+        Note:
+            Currently limited to one node, and will be expanded to
+            return information for each node that this instance is
+            connected to.
+
+        """
+        return self.transport.forward_request(
+            method='GET', path='/', headers=headers)
+
+    def api_info(self, headers=None):
+        """Retrieves information provided by the API root endpoint
+        ``'/api/v1'``.
+
+        Args:
+            headers (dict): Optional headers to pass to the request.
+
+        Returns:
+            dict: Details of the HTTP API provided by the BigchainDB
+            server.
+
+        """
+        return self.transport.forward_request(
+            method='GET',
+            path=self.api_prefix,
+            headers=headers,
+        )
+
 
 class NamespacedDriver:
     """Base class for creating endpoints (namespaced objects) that can be added

--- a/compose/server/Dockerfile
+++ b/compose/server/Dockerfile
@@ -10,4 +10,3 @@ RUN pip install --upgrade pip ipdb ipython
 COPY . /usr/src/app/
 
 RUN pip install git+https://github.com/bigchaindb/bigchaindb.git
-RUN bigchaindb -y configure rethinkdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./tox.ini:/usr/src/app/tox.ini
     environment:
       BDB_HOST: bdb-server
+      BIGCHAINDB_KEYPAIR_PUBLIC: GW1nrdZm4mbVC8ePeiGWz6DqHexqewqy5teURVHi3RG4
     command: pytest -v
   rdb:
     image: rethinkdb
@@ -24,6 +25,8 @@ services:
     environment:
       BIGCHAINDB_DATABASE_HOST: rdb
       BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
+      BIGCHAINDB_KEYPAIR_PUBLIC: GW1nrdZm4mbVC8ePeiGWz6DqHexqewqy5teURVHi3RG4
+      BIGCHAINDB_KEYPAIR_PRIVATE: 2kQgBtQnHoauw8QchKM7xYvEBW1QDoHzhBsCL9Vi1AzB 
     ports:
       - "9984"
     command: bigchaindb start

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -49,7 +49,7 @@ an instance:
 This instantiates an object ``bdb`` of class
 :class:`~bigchaindb_driver.BigchainDB`. When instantiating a
 :class:`~bigchaindb_driver.BigchainDB` object without arguments (as above), it
-uses the default BigchainDB API Root Endpoint ``http://localhost:9984/api/v1``.
+uses the default BigchainDB Root URL Endpoint ``http://localhost:9984``.
 
 If you want to connect to something other than a BigchainDB node on localhost,
 see :doc:`the page about other connection options <connect>`.

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -18,10 +18,9 @@ class so we can use it to connect:
 
     from bigchaindb_driver import BigchainDB
 
-Finally, to make the connection, you need to know
-the BigchainDB "API Root Endpoint"
-of a BigchainDB node or cluster.
-There are several possible cases, listed below.
+Finally, to make the connection, you need to know the BigchainDB Root URL of
+the BigchainDB node or cluster where HTTP requests can be sent. There are
+several possible cases, listed below.
 
 Case 1: BigchainDB on localhost
 -------------------------------
@@ -33,10 +32,8 @@ you would connect to the local BigchainDB server using:
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://localhost:9984/api/v1')
+    bdb = BigchainDB('http://localhost:9984')
 
-(This assumes the API version is v1. You may have to change that if
-the node is running a different-version HTTP API.)
 
 Case 2: A Known BigchainDB API Root Endpoint
 --------------------------------------------
@@ -52,13 +49,13 @@ Here are some examples:
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://example.com:9984/api/v1')
-    bdb = BigchaindB('http://api.example.com:9984/api/v1')
-    bdb = BigchaindB('http://example.com:1234/api/v1')
-    bdb = BigchaindB('http://example.com/api/v1')  # http is port 80 by default
-    bdb = BigchaindB('https://example.com/api/v1')  # https is port 443 by default
-    bdb = BigchaindB('http://12.34.56.123:9984/api/v1')
-    bdb = BigchaindB('http://12.34.56.123:5000/api/v1')
+    bdb = BigchainDB('http://example.com:9984')
+    bdb = BigchaindB('http://api.example.com:9984')
+    bdb = BigchaindB('http://example.com:1234')
+    bdb = BigchaindB('http://example.com')  # http is port 80 by default
+    bdb = BigchaindB('https://example.com')  # https is port 443 by default
+    bdb = BigchaindB('http://12.34.56.123:9984')
+    bdb = BigchaindB('http://12.34.56.123:5000')
 
 Case 3: Docker Container on localhost
 -------------------------------------
@@ -70,7 +67,7 @@ information), and wish to connect to it from the ``bdb-driver`` linked
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
 
 Alternatively, you may connect to the containerized BigchainDB node from
 "outside", in which case you need to know the port binding:
@@ -82,7 +79,7 @@ Alternatively, you may connect to the containerized BigchainDB node from
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://0.0.0.0:32780/api/v1')
+    bdb = BigchainDB('http://0.0.0.0:32780')
 
 
 

--- a/docs/handcraft.rst
+++ b/docs/handcraft.rst
@@ -607,7 +607,7 @@ Sending it over to a BigchainDB node:
 
     from bigchaindb_driver import BigchainDB
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
     returned_creation_tx = bdb.transactions.send(handcrafted_creation_tx)
 
 A few checks:
@@ -1014,7 +1014,7 @@ Sending it over to a BigchainDB node:
 
     from bigchaindb_driver import BigchainDB
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
     returned_transfer_tx = bdb.transactions.send(handcrafted_transfer_tx)
 
 A few checks:
@@ -1137,7 +1137,7 @@ Sending it over to a BigchainDB node:
 
     from bigchaindb_driver import BigchainDB
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
     returned_creation_tx = bdb.transactions.send(token_creation_tx)
 
 A few checks:
@@ -1256,7 +1256,7 @@ Sending it over to a BigchainDB node:
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
     returned_transfer_tx = bdb.transactions.send(token_transfer_tx)
 
 A few checks:
@@ -1731,7 +1731,7 @@ Sending it over to a BigchainDB node:
 
     from bigchaindb_driver import BigchainDB
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
     returned_car_creation_tx = bdb.transactions.send(handcrafted_car_creation_tx)
 
 Wait for some nano seconds, and check the status:
@@ -1836,7 +1836,7 @@ Sending it over to a BigchainDB node:
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
     returned_car_transfer_tx = bdb.transactions.send(handcrafted_car_transfer_tx)
 
 Wait for some nano seconds, and check the status:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,11 +14,11 @@ For the sake of these examples, we'll assume:
 
     In [0]: from bigchaindb_driver import BigchainDB
 
-    In [0]: bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    In [0]: bdb = BigchainDB('http://bdb-server:9984')
 
 .. important::
 
-    You will want to change the instances of ``'http://bdb-server:9984/api/v1'``
+    You will want to change the instances of ``'http://bdb-server:9984'``
     to be the URL of the node you want to connect to. See the :doc:`docs on
     connecting <connect>` for more information.
 
@@ -273,7 +273,7 @@ Recap: Asset Creation & Transfer
 
     alice, bob = generate_keypair(), generate_keypair()
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
 
     bicycle_asset = {
         'data': {
@@ -378,7 +378,7 @@ Handling cases for which the transaction ``id`` may not be found:
     logger = logging.getLogger(__name__)
     logging.basicConfig(format='%(asctime)-15s %(status)-3s %(message)s')
 
-    bdb = BigchainDB('http://bdb-server:9984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984')
     txid = '12345'
     try:
         status = bdb.transactions.status(txid)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env = 
+    D:BIGCHAINDB_KEYPAIR_PUBLIC=GW1nrdZm4mbVC8ePeiGWz6DqHexqewqy5teURVHi3RG4

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ tests_require = [
     'flake8>=2.6.0',
     'pytest>=3.0.1',
     'pytest-cov',
+    'pytest-env',
     'pytest-sugar',
     'pytest-xdist',
     'responses',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,11 @@ def bdb_port():
 
 
 @fixture
+def bdb_node_pubkey():
+    return environ['BIGCHAINDB_KEYPAIR_PUBLIC']
+
+
+@fixture
 def bdb_node(bdb_host, bdb_port):
     return 'http://{host}:{port}'.format(host=bdb_host, port=bdb_port)
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -31,6 +31,24 @@ class TestBigchainDB:
         assert driver.transactions
         assert driver.outputs
 
+    def test_info(self, driver, bdb_node_pubkey):
+        response = driver.info()
+        assert '_links' in response
+        assert 'docs' in response['_links']
+        assert response['keyring'] == []
+        assert response['public_key'] == bdb_node_pubkey
+        assert response['software'] == 'BigchainDB'
+        assert 'version' in response
+
+    def test_api_info(self, driver):
+        response = driver.api_info()
+        assert '_links' in response
+        assert 'docs' in response['_links']
+        api_root = driver.nodes[0] + driver.api_prefix + '/'
+        assert response['_links']['self'] == api_root
+        assert response['_links']['transactions'] == api_root + 'transactions/'
+        assert response['_links']['statuses'] == api_root + 'statuses/'
+
 
 class TestTransactionsEndpoint:
 


### PR DESCRIPTION
Add support for:

* `GET /`
* `GET /api/{version}`

via the `BigchainDB` class, which now only requires the scheme, hostname and port (e.g.: http://localhost:9984')

- [x] Document new methods (`node_info`, `api_info`)
- [x] Update connection docs