### PR TITLE
Add back `bdb` instance into basic usage examples

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -129,7 +129,7 @@ Here's some code that keeps checking the status of the transaction until it is v
     ...             break
     ...     except bigchaindb_driver.exceptions.NotFoundError:
     ...         trials += 1
-    
+
     >>> bdb.transactions.status(txid)
     {'status': 'valid'}
 
@@ -256,11 +256,11 @@ Recap: Asset Creation & Transfer
 	from bigchaindb_driver.crypto import generate_keypair
 	from time import sleep
 	from sys import exit
-	
+
 	alice, bob = generate_keypair(), generate_keypair()
-	
+
 	bdb = BigchainDB('http://localhost:59984/api/v1')
-	
+
 	bicycle_asset = {
 		'data': {
 			'bicycle': {
@@ -269,27 +269,27 @@ Recap: Asset Creation & Transfer
 			},
 		},
 	}
-	
+
 	bicycle_asset_metadata = {
 		'planet': 'earth'
 	}
-	
+
 	prepared_creation_tx = bdb.transactions.prepare(
 		operation='CREATE',
 		signers=alice.public_key,
 		asset=bicycle_asset,
 		metadata=bicycle_asset_metadata
 	)
-	
+
 	fulfilled_creation_tx = bdb.transactions.fulfill(
 		prepared_creation_tx,
 		private_keys=alice.private_key
 	)
-	
+
 	sent_creation_tx = bdb.transactions.send(fulfilled_creation_tx)
-	
+
 	txid = fulfilled_creation_tx['id']
-	
+
 	trials = 0
 	while trials < 60:
 		try:
@@ -299,20 +299,20 @@ Recap: Asset Creation & Transfer
 		except bigchaindb_driver.exceptions.NotFoundError:
 			trials += 1
 			sleep(1)
-	
+
 	if trials == 60:
 		print('Tx is still being processed... Bye!')
 		exit(0)
-	
+
 	asset_id = txid
-	
+
 	transfer_asset = {
 		'id': asset_id
 	}
-	
+
 	output_index = 0
 	output = fulfilled_creation_tx['outputs'][output_index]
-	
+
 	transfer_input = {
 		'fulfillment': output['condition']['details'],
 		'fulfills': {
@@ -321,24 +321,24 @@ Recap: Asset Creation & Transfer
 		},
 		'owners_before': output['public_keys']
 	}
-	
+
 	prepared_transfer_tx = bdb.transactions.prepare(
 		operation='TRANSFER',
 		asset=transfer_asset,
 		inputs=transfer_input,
 		recipients=bob.public_key,
 	)
-	
+
 	fulfilled_transfer_tx = bdb.transactions.fulfill(
 		prepared_transfer_tx,
 		private_keys=alice.private_key,
 	)
-	
+
 	sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx)
-	
+
 	print("Is Bob the owner?",
 		sent_transfer_tx['outputs'][0]['public_keys'][0] == bob.public_key)
-	
+
 	print("Was Alice the previous owner?",
 		fulfilled_transfer_tx['inputs'][0]['owners_before'][0] == alice.public_key)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,6 +8,14 @@ First, make sure you're using Python 3,
 you've :doc:`installed the bigchaindb_driver Python package <quickstart>`,
 and you've :doc:`connected to a BigchainDB node or cluster <connect>`.
 
+For the sake of these examples, we'll assume:
+
+.. ipython::
+
+    In [0]: from bigchaindb_driver import BigchainDB
+
+    In [0]: bdb = BigchainDB('http://bdb-server:9984/api/v1')
+
 Digital Asset Definition
 ------------------------
 As an example, let's consider the creation and transfer of a digital asset that
@@ -259,7 +267,7 @@ Recap: Asset Creation & Transfer
 
     alice, bob = generate_keypair(), generate_keypair()
 
-    bdb = BigchainDB('http://localhost:59984/api/v1')
+    bdb = BigchainDB('http://bdb-server:9984/api/v1')
 
     bicycle_asset = {
         'data': {

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -252,95 +252,95 @@ Recap: Asset Creation & Transfer
 
 .. code-block:: python
 
-	from bigchaindb_driver import BigchainDB
-	from bigchaindb_driver.crypto import generate_keypair
-	from time import sleep
-	from sys import exit
+    from bigchaindb_driver import BigchainDB
+    from bigchaindb_driver.crypto import generate_keypair
+    from time import sleep
+    from sys import exit
 
-	alice, bob = generate_keypair(), generate_keypair()
+    alice, bob = generate_keypair(), generate_keypair()
 
-	bdb = BigchainDB('http://localhost:59984/api/v1')
+    bdb = BigchainDB('http://localhost:59984/api/v1')
 
-	bicycle_asset = {
-		'data': {
-			'bicycle': {
-				'serial_number': 'abcd1234',
-				'manufacturer': 'bkfab'
-			},
-		},
-	}
+    bicycle_asset = {
+        'data': {
+            'bicycle': {
+                'serial_number': 'abcd1234',
+                'manufacturer': 'bkfab'
+            },
+        },
+    }
 
-	bicycle_asset_metadata = {
-		'planet': 'earth'
-	}
+    bicycle_asset_metadata = {
+        'planet': 'earth'
+    }
 
-	prepared_creation_tx = bdb.transactions.prepare(
-		operation='CREATE',
-		signers=alice.public_key,
-		asset=bicycle_asset,
-		metadata=bicycle_asset_metadata
-	)
+    prepared_creation_tx = bdb.transactions.prepare(
+        operation='CREATE',
+        signers=alice.public_key,
+        asset=bicycle_asset,
+        metadata=bicycle_asset_metadata
+    )
 
-	fulfilled_creation_tx = bdb.transactions.fulfill(
-		prepared_creation_tx,
-		private_keys=alice.private_key
-	)
+    fulfilled_creation_tx = bdb.transactions.fulfill(
+        prepared_creation_tx,
+        private_keys=alice.private_key
+    )
 
-	sent_creation_tx = bdb.transactions.send(fulfilled_creation_tx)
+    sent_creation_tx = bdb.transactions.send(fulfilled_creation_tx)
 
-	txid = fulfilled_creation_tx['id']
+    txid = fulfilled_creation_tx['id']
 
-	trials = 0
-	while trials < 60:
-		try:
-			if bdb.transactions.status(txid).get('status') == 'valid':
-				print('Tx valid in:', trials, 'secs')
-				break
-		except bigchaindb_driver.exceptions.NotFoundError:
-			trials += 1
-			sleep(1)
+    trials = 0
+    while trials < 60:
+        try:
+            if bdb.transactions.status(txid).get('status') == 'valid':
+                print('Tx valid in:', trials, 'secs')
+                break
+        except bigchaindb_driver.exceptions.NotFoundError:
+            trials += 1
+            sleep(1)
 
-	if trials == 60:
-		print('Tx is still being processed... Bye!')
-		exit(0)
+    if trials == 60:
+        print('Tx is still being processed... Bye!')
+        exit(0)
 
-	asset_id = txid
+    asset_id = txid
 
-	transfer_asset = {
-		'id': asset_id
-	}
+    transfer_asset = {
+        'id': asset_id
+    }
 
-	output_index = 0
-	output = fulfilled_creation_tx['outputs'][output_index]
+    output_index = 0
+    output = fulfilled_creation_tx['outputs'][output_index]
 
-	transfer_input = {
-		'fulfillment': output['condition']['details'],
-		'fulfills': {
-			'output': output_index,
-			'txid': fulfilled_creation_tx['id']
-		},
-		'owners_before': output['public_keys']
-	}
+    transfer_input = {
+        'fulfillment': output['condition']['details'],
+        'fulfills': {
+            'output': output_index,
+            'txid': fulfilled_creation_tx['id']
+        },
+        'owners_before': output['public_keys']
+    }
 
-	prepared_transfer_tx = bdb.transactions.prepare(
-		operation='TRANSFER',
-		asset=transfer_asset,
-		inputs=transfer_input,
-		recipients=bob.public_key,
-	)
+    prepared_transfer_tx = bdb.transactions.prepare(
+        operation='TRANSFER',
+        asset=transfer_asset,
+        inputs=transfer_input,
+        recipients=bob.public_key,
+    )
 
-	fulfilled_transfer_tx = bdb.transactions.fulfill(
-		prepared_transfer_tx,
-		private_keys=alice.private_key,
-	)
+    fulfilled_transfer_tx = bdb.transactions.fulfill(
+        prepared_transfer_tx,
+        private_keys=alice.private_key,
+    )
 
-	sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx)
+    sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx)
 
-	print("Is Bob the owner?",
-		sent_transfer_tx['outputs'][0]['public_keys'][0] == bob.public_key)
+    print("Is Bob the owner?",
+        sent_transfer_tx['outputs'][0]['public_keys'][0] == bob.public_key)
 
-	print("Was Alice the previous owner?",
-		fulfilled_transfer_tx['inputs'][0]['owners_before'][0] == alice.public_key)
+    print("Was Alice the previous owner?",
+        fulfilled_transfer_tx['inputs'][0]['owners_before'][0] == alice.public_key)
 
 
 Transaction Status

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,6 +16,12 @@ For the sake of these examples, we'll assume:
 
     In [0]: bdb = BigchainDB('http://bdb-server:9984/api/v1')
 
+.. important::
+
+    You will want to change the instances of ``'http://bdb-server:9984/api/v1'``
+    to be the URL of the node you want to connect to. See the :doc:`docs on
+    connecting <connect>` for more information.
+
 Digital Asset Definition
 ------------------------
 As an example, let's consider the creation and transfer of a digital asset that
@@ -372,8 +378,6 @@ Handling cases for which the transaction ``id`` may not be found:
     logger = logging.getLogger(__name__)
     logging.basicConfig(format='%(asctime)-15s %(status)-3s %(message)s')
 
-    # NOTE: You may need to change the URL.
-    # E.g.: 'http://localhost:9984/api/v1'
     bdb = BigchainDB('http://bdb-server:9984/api/v1')
     txid = '12345'
     try:


### PR DESCRIPTION
I do think we still need this bit... see https://github.com/bigchaindb/bigchaindb-driver/pull/251/files#r99296405.

Fixes some extraneous whitespace and tabs as well. Only commit that has non-cosmetic changes is 534961e.