### PR TITLE
docs simplifications/clarifications

### DIFF
--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -4,7 +4,7 @@
 Advanced Usage Examples
 =======================
 
-This section has examples of using the Python Driver for more advanced use
+This page has examples of using the Python Driver for more advanced use
 cases such as escrow.
 
 .. todo:: This is work in progress. More examples will gradually appear as issues like
@@ -13,46 +13,30 @@ cases such as escrow.
 
     are taken care of.
 
+For the examples on this page,
+we assume you're using a Python 3 version of IPython (or similar),
+you've :doc:`installed the bigchaindb_driver Python package <quickstart>`,
+and :doc:`you have determined the BigchainDB Root URL <connect>`
+of the node or cluster you want to connect to.
+
 
 Getting Started
 ---------------
 
-First, make sure you have RethinkDB and BigchainDB Server
-`installed and running <https://docs.bigchaindb.com/projects/server/en/latest/dev-and-test/setup-run-node.html>`_,
-e.g.:
-
-.. code-block:: bash
-
-    $ rethinkdb --daemon
-    $ bigchaindb configure
-    $ bigchaindb start
-
-Don't shut them down!
-
-Next, make sure you've :doc:`installed the bigchaindb_driver Python package <quickstart>`.
-Then, in a new terminal, run an IPython shell:
-
-.. code-block:: bash
-
-    $ ipython
-
-Make sure it's Python 3.
-Now we can import the :class:`~bigchaindb_driver.BigchainDB` class and create
-an instance:
+We begin by creating an object of class BigchainDB:
 
 .. ipython::
 
     In [0]: from bigchaindb_driver import BigchainDB
 
-    In [0]: bdb = BigchainDB()
+    In [0]: bdb_root_url = 'https://example.com:9984'  # Use YOUR BigchainDB Root URL here
 
-This instantiates an object ``bdb`` of class
+    In [0]: bdb = BigchainDB(bdb_root_url)
+
+That last command instantiates an object ``bdb`` of class
 :class:`~bigchaindb_driver.BigchainDB`. When instantiating a
-:class:`~bigchaindb_driver.BigchainDB` object without arguments (as above), it
-uses the default BigchainDB Root URL Endpoint ``http://localhost:9984``.
-
-If you want to connect to something other than a BigchainDB node on localhost,
-see :doc:`the page about other connection options <connect>`.
+:class:`~bigchaindb_driver.BigchainDB` object without arguments, it
+uses the default BigchainDB Root URL ``http://localhost:9984``.
 
 
 Create a Digital Asset

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -1,26 +1,14 @@
 .. _connect:
 
-===============
-Step 2: Connect
-===============
+=================================
+Determine the BigchainDB Root URL
+=================================
 
-If you want to use the BigchainDB Python driver to communicate
-with a BigchainDB node or cluster, the first step is to connect to one.
-This page explains how to do that.
+If you want to use the BigchainDB Python Driver
+to communicate with a BigchainDB node or cluster,
+then you will need its BigchainDB Root URL.
+This page is to help you determine it.
 
-First, make sure you're using Python 3 and you've
-:doc:`installed the bigchaindb_driver Python package <quickstart>`.
-
-Next, in Python, import the :class:`BigchainDB <bigchaindb_driver.BigchainDB>`
-class so we can use it to connect:
-
-.. code-block:: python
-
-    from bigchaindb_driver import BigchainDB
-
-Finally, to make the connection, you need to know the BigchainDB Root URL of
-the BigchainDB node or cluster where HTTP requests can be sent. There are
-several possible cases, listed below.
 
 Case 1: BigchainDB on localhost
 -------------------------------
@@ -28,20 +16,20 @@ Case 1: BigchainDB on localhost
 If a BigchainDB node is running locally
 (and the ``BIGCHAINDB_SERVER_BIND`` setting wasn't changed
 from the default ``localhost:9984``),
-you would connect to the local BigchainDB server using:
+then the BigchainDB Root URL is:
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://localhost:9984')
+   bdb_root_url = 'http://localhost:9984'
 
 
-Case 2: A Known BigchainDB API Root Endpoint
---------------------------------------------
+Case 2: A Cluster Hosted by Someone Else
+----------------------------------------
 
 If you're connecting to a BigchainDB cluster hosted
 by someone else, then they'll tell you their
-API Root Endpoint.
-A BigchainDB API Root endpoint can take many forms.
+BigchaindB Root URL.
+It can take many forms.
 It can use HTTP or HTTPS.
 It can use a hostname or an IP address.
 The port might not be 9984.
@@ -49,13 +37,13 @@ Here are some examples:
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://example.com:9984')
-    bdb = BigchaindB('http://api.example.com:9984')
-    bdb = BigchaindB('http://example.com:1234')
-    bdb = BigchaindB('http://example.com')  # http is port 80 by default
-    bdb = BigchaindB('https://example.com')  # https is port 443 by default
-    bdb = BigchaindB('http://12.34.56.123:9984')
-    bdb = BigchaindB('http://12.34.56.123:5000')
+    bdb_root_url = 'http://example.com:9984'
+    bdb_root_url = 'http://api.example.com:9984'
+    bdb_root_url = 'http://example.com:1234'
+    bdb_root_url = 'http://example.com'  # http is port 80 by default
+    bdb_root_url = 'https://example.com'  # https is port 443 by default
+    bdb_root_url = 'http://12.34.56.123:9984'
+    bdb_root_url = 'http://12.34.56.123:5000'
 
 Case 3: Docker Container on localhost
 -------------------------------------
@@ -67,7 +55,7 @@ information), and wish to connect to it from the ``bdb-driver`` linked
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://bdb-server:9984')
+    bdb_root_url = 'http://bdb-server:9984'
 
 Alternatively, you may connect to the containerized BigchainDB node from
 "outside", in which case you need to know the port binding:
@@ -79,8 +67,10 @@ Alternatively, you may connect to the containerized BigchainDB node from
 
 .. code-block:: python
 
-    bdb = BigchainDB('http://0.0.0.0:32780')
+    bdb_root_url = 'http://0.0.0.0:32780'
 
+
+Next, try some of the :doc:`basic usage examples <usage>`.
 
 
 .. _bigchaindb_driver: https://github.com/bigchaindb/bigchaindb-driver

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -15,7 +15,7 @@ If you're missing one of those, then see below. Otherwise, you can install the B
 
     pip install bigchaindb_driver
 
-and then you can try the :doc:`Basic Usage Examples <usage>`.
+Next: :doc:`determine the BigchainDB Root URL of the BigchainDB node or cluster you want to connect to <connect>`.
 
 
 How to Install the Dependencies

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -10,6 +10,10 @@ you've :doc:`installed the bigchaindb_driver Python package <quickstart>`,
 and :doc:`you have determined the BigchainDB Root URL <connect>`
 of the node or cluster you want to connect to.
 
+
+Getting Started
+---------------
+
 We begin by creating an object of class BigchainDB:
 
 .. ipython::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,7 +22,20 @@ We begin by creating an object of class BigchainDB:
 
     In [0]: bdb_root_url = 'https://example.com:9984'  # Use YOUR BigchainDB Root URL here
 
+If the BigchainDB node or cluster doesn't require authentication tokens, you can do: 
+
+.. ipython::
+
     In [0]: bdb = BigchainDB(bdb_root_url)
+
+If it *does* require authentication tokens, you can do put them in a dict like so:
+
+.. ipython::
+
+    In [0]: tokens = {'app_id': 'your_app_id', 'app_key': 'your_app_key'}
+
+    In [0]: bdb = BigchainDB(bdb_root_url, headers=tokens)
+
 
 
 Digital Asset Definition

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,23 +4,22 @@
 Basic Usage Examples
 ====================
 
-First, make sure you're using Python 3,
+For the examples on this page,
+we assume you're using a Python 3 version of IPython (or similar),
 you've :doc:`installed the bigchaindb_driver Python package <quickstart>`,
-and you've :doc:`connected to a BigchainDB node or cluster <connect>`.
+and :doc:`you have determined the BigchainDB Root URL <connect>`
+of the node or cluster you want to connect to.
 
-For the sake of these examples, we'll assume:
+We begin by creating an object of class BigchainDB:
 
 .. ipython::
 
     In [0]: from bigchaindb_driver import BigchainDB
 
-    In [0]: bdb = BigchainDB('http://bdb-server:9984')
+    In [0]: bdb_root_url = 'https://example.com:9984'  # Use YOUR BigchainDB Root URL here
 
-.. important::
+    In [0]: bdb = BigchainDB(bdb_root_url)
 
-    You will want to change the instances of ``'http://bdb-server:9984'``
-    to be the URL of the node you want to connect to. See the :doc:`docs on
-    connecting <connect>` for more information.
 
 Digital Asset Definition
 ------------------------
@@ -273,7 +272,9 @@ Recap: Asset Creation & Transfer
 
     alice, bob = generate_keypair(), generate_keypair()
 
-    bdb = BigchainDB('http://bdb-server:9984')
+    bdb_root_url = 'https://example.com:9984'  # Use YOUR BigchainDB Root URL here
+
+    bdb = BigchainDB(bdb_root_url)
 
     bicycle_asset = {
         'data': {
@@ -378,7 +379,8 @@ Handling cases for which the transaction ``id`` may not be found:
     logger = logging.getLogger(__name__)
     logging.basicConfig(format='%(asctime)-15s %(status)-3s %(message)s')
 
-    bdb = BigchainDB('http://bdb-server:9984')
+    bdb_root_url = 'https://example.com:9984'  # Use YOUR BigchainDB Root URL here
+    bdb = BigchainDB(bdb_root_url)
     txid = '12345'
     try:
         status = bdb.transactions.status(txid)


### PR DESCRIPTION
Trent made some comments about the Python Driver docs this morning. I think these changes might help. For example, now there is no "Step 2" without a "Step 1" before it.

I also streamlined some of the language and presentation, to make it easier to follow.