### PR TITLE
Update from alpha to beta

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,6 @@
 
 BigchainDB Python Driver
 ========================
-
-.. important:: **Development Status: Alpha**
     
 .. toctree::
    :maxdepth: 1

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     zip_safe=False,
     keywords='bigchaindb_driver',
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',


### PR DESCRIPTION
In `setup.py`, I changed the classifier `'Development Status :: 3 - Alpha'` to `'Development Status :: 4 - Beta'` as per the list of classifiers here: https://pypi.python.org/pypi?%3Aaction=list_classifiers

I also removed the "Important" notice about "Development Status: Alpha" from the Index page.

This is in preparation for the version 1.0 release (of BigchainDB Server) but I think it's probably fine to have it in master now.