### PR TITLE
Fix skip of assets tests

### DIFF
--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import os
 import json
 
 import base58
 from pytest import mark, raises
 from requests.utils import default_headers
 
+import bigchaindb
 from cryptoconditions import Ed25519Sha256
 
 
@@ -214,7 +214,7 @@ class TestBlocksEndppoint:
         assert block
 
 
-@mark.skipif(os.environ['BIGCHAINDB_DATABASE_BACKEND'] != 'mongodb',
+@mark.skipif(bigchaindb.config['database']['backend'] != 'mongodb',
              reason='Requires MongoDB as the backend')
 class TestAssetsEndpoint:
 


### PR DESCRIPTION
Changed the skip condition for the assets tests.
It now checks what is the backend being used in the bigchaindb config instead of the environment variable. This way we can run the tests without having to set the environment variable. Useful when testing locally.