### PR TITLE
Minor changes in the quickstart guide for installation of bdb-driver

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,11 +4,10 @@ Quickstart / Installation
 
 The BigchainDB Python Driver depends on:
 
-1. ``libffi/ffi.h``
-2. ``libssl-dev``
-3. Python 3.5+
-4. A recent Python 3 version of ``pip``
-5. A recent Python 3 version of ``setuptools``
+1. Python 3.5+
+2. A recent Python 3 version of ``pip``
+3. A recent Python 3 version of ``setuptools``
+4. cryptography and cryptoconditions
 
 If you're missing one of those, then see below. Otherwise, you can install the BigchainDB Python Driver (``bigchaindb_driver``) using:
 
@@ -22,55 +21,8 @@ Next: :doc:`determine the BigchainDB Root URL of the BigchainDB node or cluster 
 How to Install the Dependencies
 -------------------------------
 
-Dependency 1: ffi.h
-^^^^^^^^^^^^^^^^^^^
 
-BigchainDB (server and driver) depends on `cryptoconditions`_,
-which depends on `PyNaCl`_ (`Networking and Cryptography library`_),
-which depends on ``ffi.h``.
-Hence, depending on your setup, you may need to install the
-development files for ``libffi``.
-
-On Ubuntu 14.04 and 16.04, this works:
-
-.. code-block:: bash
-
-    $ sudo apt-get update
-
-    $ sudo apt-get install libffi-dev
-
-On Fedora 23 and 24, this works:
-
-.. code-block:: bash
-
-    $ sudo dnf update
-
-    $ sudo dnf install libffi-devel
-
-For other operating systems, just do some web searches for "ffi.h" with the name of your OS.
-
-Dependency 2: libssl-dev
-^^^^^^^^^^^^^^^^^^^^^^^^
-BigchainDB (server and driver) also depends on `cryptography`_,
-which in turn depends on `libssl`_ AND `libcrypto`_.
-Hence, depending on your setup you need to install the `libssl-dev`_ (Ubuntu)
-OR `openssl-devel`_ (RHEL) package, which installs the development
-libraries and header files for `libssl`_ and `libcrypto`_.
-
-On Ubuntu 14.04 and 16.04:
-
-.. code-block:: bash
-
-    $ sudo apt-get install libssl-dev
-
-On Fedora 23 and 24:
-
-.. code-block:: bash
-
-    $ sudo dnf install openssl-devel
-
-
-Dependency 3: Python 3.5+
+Dependency 1: Python 3.5+
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The BigchainDB Python Driver uses Python 3.5+. You can check your version of Python using:
@@ -86,7 +38,7 @@ The BigchainDB Python Driver uses Python 3.5+. You can check your version of Pyt
 An easy way to install a specific version of Python, and to switch between versions of Python, is to use `virtualenv <https://virtualenv.pypa.io/en/latest/>`_. Another option is `conda <http://conda.pydata.org/docs/>`_.
 
 
-Dependency 4: pip
+Dependency 2: pip
 ^^^^^^^^^^^^^^^^^
 
 You also need to get a recent, Python 3 version of ``pip``, the Python package manager.
@@ -109,7 +61,7 @@ then see `the pip documentation <https://pip.pypa.io/en/stable/installing/>`_
 or our page about that in the `BigchainDB Server docs <https://docs.bigchaindb.com/projects/server/en/latest/appendices/install-latest-pip.html>`_.
 
 
-Dependency 5: setuptools
+Dependency 3: setuptools
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once you have a recent Python 3 version of ``pip``, you should be able to upgrade ``setuptools`` using:
@@ -122,6 +74,32 @@ Once you have a recent Python 3 version of ``pip``, you should be able to upgrad
 
     $ pip3 install --upgrade setuptools
 
+
+Dependency 4: cryptography and cryptoconditions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+BigchainDB(server and driver) also depends on `cryptography`_ and `cryptoconditions`_.
+
+* `cryptography`_ depends on `libssl`_, `libcrypto`_ which also depends on (`Python development library and header files`_).
+* `cryptoconditions`_ depends on `PyNaCl`_ (`Networking and Cryptography library`_) which depends on ``ffi.h``.
+
+On Ubuntu 14.04 and 16.04, this works:
+
+.. code-block:: bash
+
+    $ sudo apt-get update
+
+    $ sudo apt-get install python3-dev libssl-dev libffi-dev
+
+On Fedora 23 and 24, this works:
+
+.. code-block:: bash
+
+    $ sudo dnf update
+
+    $ sudo dnf install python-devel openssl-devel libffi-devel
+
+For other operating systems, please refer to `the cryptography installation guide <https://cryptography.io/en/latest/installation/#installation>`_.
 
 
 Installing the Driver
@@ -154,3 +132,4 @@ See the :doc:`Advanced Installation Options <advanced-installation>` page.
 .. _openssl-devel: https://rpmfind.net/linux/rpm2html/search.php?query=openssl-devel
 .. _libssl: https://github.com/openssl/openssl
 .. _libcrypto: https://github.com/openssl/openssl
+.. _Python development library and header files: https://github.com/python/cpython


### PR DESCRIPTION
* Adding python development library and headers as a dependency for
cryptography.
* Also reference to official cryptography installation guide.
* Restructure document