### PR TITLE
Add standard template for creating PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
 ## Description
 A few sentences describing the overall goals of the pull request's commits.
 
-## Feature Status
-**READY/IN DEVELOPMENT**
+## Issues This PR Fixes
+Fixes #NNNN
+Fixes #NNNN
 
 ## Related PRs
 List related PRs against other branches e.g. for backporting features/bugfixes
@@ -16,8 +17,7 @@ some_other_PR | [link]()
 ## Todos
 - [ ] Tested and working on development environment
 - [ ] Unit tests (if appropriate)
-- [ ] New API endpoints documented. Add [link]() if different from this PR 
-- [ ] Reviewed and approved by a senior dev
+- [ ] Added/Updated all related documentation. Add [link]() if different from this PR
 - [ ] DevOps Support needed e.g. create Runscope API test if new endpoint added or
       update deployment docs. Create a ticket and add [link]()
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+
+## Feature Status
+**READY/IN DEVELOPMENT**
+
+## Related PRs
+List related PRs against other branches e.g. for backporting features/bugfixes
+to previous release branches:
+
+Repo/Branch | PR
+------ | ------
+some_other_PR | [link]()
+
+
+## Todos
+- [ ] Tested and working on development environment
+- [ ] Unit tests (if appropriate)
+- [ ] New API endpoints documented. Add [link]() if different from this PR 
+- [ ] Reviewed and approved by a senior dev
+- [ ] DevOps Support needed e.g. create Runscope API test if new endpoint added or
+      update deployment docs. Create a ticket and add [link]()
+
+## Deployment Notes
+Notes about how to deploy this work. For example, running a migration against the production DB.
+
+## How to QA
+Outline the steps to test or reproduce the PR here.
+
+## Impacted Areas in Application
+List general components of the application that this PR will affect:
+- Scale
+- Performance
+- Security etc.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -108,6 +108,8 @@ Before you submit a pull request, check that it meets these guidelines:
 3. The pull request should work for Python 3.5, and pass the flake8 check.
    Check https://travis-ci.org/bigchaindb/bigchaindb-driver/pull_requests
    and make sure that the tests pass for all supported Python versions.
+4. Follow the pull request template while creating new PRs, the template will
+   be visible to you when you create a new pull request.
 
 Tips
 ----


### PR DESCRIPTION
## Description
Recently while updating test net k8s cluster a recently added API endpoint
was skipped from testing because DevOps team was not aware of the new
endpoint and an issue with this endpoint on new cluster was only caught after
we moved the test net to new cluster. To avoid this in the future this PR adds a 
standard PR template to delegate dependencies whenever applicable.

## Feature Status
**READY**

## Related PRs

Repo/Branch | PR
------ | ------
bigchaindb/bigchaindb | [link](https://github.com/bigchaindb/bigchaindb/pull/1776)

## Todos
- [x] Documented in CONTRIBUTING.rst
- [ ] Reviewed and approved by a senior dev

## Deployment Notes
No impact on deployment

## How to QA
Create a new PR and the template should be visible

## Impacted Areas in Application
- No Scale impact
- No Performance impact
- No Security impact
- Documentation impact: Developer documentation needs to be updated