### PR TITLE
Problem: the status parameter for querying a block is deprecated

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -410,8 +410,7 @@ class BlocksEndpoint(NamespacedDriver):
     PATH = '/blocks/'
 
     def get(self, *, txid, headers=None):
-        """Get the block(s) that contain the given transaction id
-        (``txid``), and optionally that have the given ``status``.
+        """Get the block(s) that contain the given transaction id (``txid``).
 
         Args:
             txid (str): Transaction id.

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -409,14 +409,12 @@ class BlocksEndpoint(NamespacedDriver):
 
     PATH = '/blocks/'
 
-    def get(self, *, txid, status=None, headers=None):
+    def get(self, *, txid, headers=None):
         """Get the block(s) that contain the given transaction id
         (``txid``), and optionally that have the given ``status``.
 
         Args:
             txid (str): Transaction id.
-            status (str): Status the block should have. Accepted values
-                are ``VALID``, ``UNDECIDED`` or ``INVALID``.
             headers (dict): Optional headers to pass to the request.
 
         Returns:
@@ -426,7 +424,7 @@ class BlocksEndpoint(NamespacedDriver):
         return self.transport.forward_request(
             method='GET',
             path=self.path,
-            params={'transaction_id': txid, 'status': status},
+            params={'transaction_id': txid},
             headers=headers,
         )
 


### PR DESCRIPTION
Solution: remove status parameter and adjust documentation

FYI: I thought we had this in our documentation, but I couldn't find anything.

## Issues This PR Fixes
#360 

## Related PRs
bigchaindb/bigchaindb#2021