### PR TITLE
Problem: block_id parameter for block query is now block_height

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -420,7 +420,7 @@ class BlocksEndpoint(NamespacedDriver):
             headers (dict): Optional headers to pass to the request.
 
         Returns:
-            :obj:`list` of :obj:`str`: List of block ids.
+            :obj:`list` of :obj:`int`: List of block heights.
 
         """
         return self.transport.forward_request(
@@ -430,18 +430,18 @@ class BlocksEndpoint(NamespacedDriver):
             headers=headers,
         )
 
-    def retrieve(self, block_id, headers=None):
+    def retrieve(self, block_height, headers=None):
         """Retrieves the transaction with the given id.
 
         Args:
-            block_id (str): Id of the block to retrieve.
+            block_height (str): height of the block to retrieve.
             headers (dict): Optional headers to pass to the request.
 
         Returns:
             dict: The block with the given id.
 
         """
-        path = self.path + block_id
+        path = self.path + block_height
         return self.transport.forward_request(
             method='GET', path=path, headers=None)
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -119,12 +119,20 @@ Read the Creation Transaction from the DB
 -----------------------------------------
 
 After a couple of seconds, we can check if the transaction was validated in a
-block:
+block.
 
 .. code-block:: python
 
-    # Retrieve a validated transaction
-    >>> tx_retrieved = bdb.transactions.retrieve(signed_tx['id'])
+    # Retrieve a block height
+    >>> block_height = bdb.transactions.get(txid=signed_tx['id'])
+
+This will return a list with block heights. If the transaction is not in any block an empty list will be returned.
+If we want some more data we can use the block height to retrieve the block itself.
+
+.. code-block:: python
+
+    # Retrieve a block
+    >>> block = bdb.transactions.retrieve(str(block_height[0]))
 
 The new owner of the digital asset is now Alice (or more correctly, her *public
 key*):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -212,7 +212,8 @@ class TestBlocksEndppoint:
         assert len(blocks) == 1
 
     def test_retrieve(self, driver, block_with_alice_transaction):
-        block = driver.blocks.retrieve(block_id=block_with_alice_transaction)
+        block = driver.blocks.retrieve(
+            block_height=str(block_with_alice_transaction))
         assert block
 
 


### PR DESCRIPTION
Solution: change parameter to block_height and update documentation

## Issues This PR Fixes
Fixes #362 

## Related PRs
bigchaindb/bigchaindb#1970

## Todo

- [ ] fixing the tests, as soon as we have a new dev environment