### PR TITLE
Problem: Dev environment is outdated and no integration with Tendermint

### DIFF
--- a/.ci/travis-after-success.sh
+++ b/.ci/travis-after-success.sh
@@ -2,6 +2,6 @@
 
 set -e -x
 
-if [ "${TOXENV}" == "py36" ]; then
+if [ "${TOXENV}" == "py35" || "${TOXENV}" == "py36" ]; then
     codecov -v
 fi

--- a/.ci/travis-after-success.sh
+++ b/.ci/travis-after-success.sh
@@ -2,6 +2,6 @@
 
 set -e -x
 
-if [ "${TOXENV}" == "py35" || "${TOXENV}" == "py36" ]; then
+if [ "${TOXENV}" == "py36" ]; then
     codecov -v
 fi

--- a/.ci/travis-before-install.sh
+++ b/.ci/travis-before-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "${TOXENV}" == "py36" ]]; then
+if [[ "${TOXENV}" == "py35" || "${TOXENV}" == "py36" ]]; then
   sudo apt-get update
   sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 

--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -2,6 +2,6 @@
 
 set -e -x
 
-if [[ "${TOXENV}" == "py36" ]]; then
+if [[ "${TOXENV}" == "py35" || "${TOXENV}" == "py36" ]]; then
     docker-compose up -d bigchaindb
 fi

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -5,7 +5,7 @@ set -e -x
 pip install --upgrade pip
 pip install --upgrade tox
 
-if [[ "${TOXENV}" == "py36" ]]; then
+if [[ "${TOXENV}" == "py35" || "${TOXENV}" == "py36" ]]; then
     docker-compose build --no-cache bigchaindb bigchaindb-driver
     pip install --upgrade codecov
 fi

--- a/.ci/travis_script.sh
+++ b/.ci/travis_script.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-if [[ "${TOXENV}" == "py36" ]]; then
+if [[ "${TOXENV}" == "py35" || "${TOXENV}" == "py36" ]]; then
   docker-compose run --rm bigchaindb-driver pytest -v
 else
   tox -e ${TOXENV}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,29 @@
 language: python
 python:
+  - 3.5
   - 3.6
 
 env:
   global:
     - DOCKER_COMPOSE_VERSION=1.19.0
   matrix:
+    - TOXENV=py35
     - TOXENV=py36
     - TOXENV=flake8
     - TOXENV=docs
-  
+
+matrix:
+  fast_finish: true
+  exclude:
+    - python: 3.5
+      env: TOXENV=flake8
+    - python: 3.5
+      env: TOXENV=docs
+    - python: 3.5
+      env: TOXENV=py36
+    - python: 3.6
+      env: TOXENV=py35
+
 before_install:
   - sudo .ci/travis-before-install.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, flake8, docs
+envlist = py35, py36, flake8, docs
 
 [base]
 basepython=python3.6


### PR DESCRIPTION
## Description
- Updated `docker-compose.yml`
- Remove `docker-compose.rdb.yml` because RethinkDB is not supported with BigchainDB v2.0
- Update Travis configuration to test with `localmongodb` and BigchainDB v2.0 instead of BigchainDB <=1.3.0 and `rethinkdb`.
- Consolidate all deployment methods in a single `docker-compose` file i.e. `docs.yml` should move into `docker-compose.yml` as well.
- Remove `dev.yml` because it is deprecated(RethinkDB is not supported with 2.0)

## Issues This PR Fixes
Fixes #368 

:fire::fire::fire: Travis will fail with this PR but we will have dependent changes that will take care of those tests @codegeschrei  can confirm :fire::fire::fire: