### PR TITLE
Problem: current BigchainDB Server version is outdated in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('CHANGELOG.rst') as changelog_file:
 
 install_requires = [
     'requests>=2.11.0',
-    'bigchaindb==1.4.0.dev',
+    'bigchaindb==2.0.0.dev',
 ]
 
 tests_require = [
@@ -75,6 +75,6 @@ setup(
         'docs': docs_require,
     },
     dependency_links=[
-        'git+https://github.com/bigchaindb/bigchaindb.git@master#egg=bigchaindb-1.4.0.dev',
+        'git+https://github.com/bigchaindb/bigchaindb.git@master#egg=bigchaindb-2.0.0.dev',
     ],
 )


### PR DESCRIPTION
Solution: update the current version to 2.0.0.dev

## Issues This PR Fixes
Fixes #370 

## Related PRs
https://github.com/bigchaindb/bigchaindb/pull/2150