### PR TITLE
Problem: building docs with docker-compose uses the docker server file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,10 +66,7 @@ services:
       - vdocs
     build:
       context: .
-      dockerfile: ./compose/bigchaindb_server/Dockerfile
-      args:
-        branch: master
-        backend: localmongodb
+      dockerfile: ./compose/bigchaindb_driver/Dockerfile
     volumes:
       - .:/usr/src/app/
     command: make -C docs html


### PR DESCRIPTION
Solution: change the docker file to driver and remove unused arguments

## Issues This PR Fixes
Fixes #372 