### PR TITLE
Problem: public key is currently not exposed in BigchainDB Server

### DIFF
--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -40,7 +40,8 @@ class TestBigchainDB:
         assert 'api' in response
         assert 'docs' in response
         assert response['keyring'] == []
-        assert response['public_key'] == bdb_node_pubkey
+        # TODO: update when server exposes public key
+        # assert response['public_key'] == bdb_node_pubkey
         assert response['software'] == 'BigchainDB'
         assert 'version' in response
 


### PR DESCRIPTION
Solutions: remove the public key from tests

## Issues This PR Fixes
Fixes #374 
