### PR TITLE
Problem: tests are sometimes failing because a transaction is not yet…

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -304,7 +304,7 @@ class TransactionsEndpoint(NamespacedDriver):
             headers=headers,
         )
 
-    def send(self, transaction, mode='async', headers=None):
+    def send(self, transaction, mode='commit', headers=None):
         """Submit a transaction to the Federation.
 
         Args:

--- a/docs/handcraft.rst
+++ b/docs/handcraft.rst
@@ -657,8 +657,8 @@ Handcrafting a ``CREATE`` transaction can be done as follows:
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 
@@ -1116,8 +1116,8 @@ In a nutshell
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 
@@ -1240,8 +1240,8 @@ Handcrafting the ``CREATE`` transaction for our :ref:`bicycle sharing example
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 
@@ -1371,8 +1371,8 @@ to Bob:
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 
@@ -1441,8 +1441,8 @@ Say ``alice`` and ``bob`` own a car together:
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 
@@ -1874,8 +1874,8 @@ Handcrafting the ``'CREATE'`` transaction
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 
@@ -1981,8 +1981,8 @@ Handcrafting the ``'TRANSFER'`` transaction
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 
@@ -2127,8 +2127,8 @@ Handcrafting the ``'CREATE'`` transaction
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 
@@ -2232,8 +2232,8 @@ Handcrafting the ``'TRANSFER'`` transaction
 To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
 used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
 By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
-``async``, which will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return
-after the transaction is validated, while ``commit`` returns after the transaction is committed to a block.
+``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
+will return after the transaction is validated, while ``async`` will return right away.
 
 .. code-block:: python
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands=
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/bigchaindb_driver
-    BIGCHAINDB_DATABASE_BACKEND=rethinkdb
+    BIGCHAINDB_DATABASE_BACKEND=mongodb
 deps =
     {[base]deps}
 install_command = pip install {opts} {packages} --process-dependency-links .[test]


### PR DESCRIPTION
… in a block

Solution: change the default mode for sending transactions to commit, to wait for a transaction to be committed to a block

## Issues This PR Fixes
Fixes #386
