### PR TITLE
Problem: docs are not building with python 3.5

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+build:
+    image: latest
+
+python:
+    version: 3.6
+    pip_install: true


### PR DESCRIPTION
Solution: change to python 3.6

To change the version from 3.5 to 3.6 a config file for readthedocs needs to be added that specifies the wanted version
