### PR TITLE
Problem: tests are sometimes failing

### DIFF
--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -3,5 +3,5 @@
 set -e -x
 
 if [[ "${TOXENV}" == "py35" || "${TOXENV}" == "py36" ]]; then
-    docker-compose up -d bigchaindb
+    docker-compose up -d bdb
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,11 @@ services:
       - "46656"
       - "46657"
     command: bash -c "tendermint init && tendermint node"
+  bdb:
+    image: busybox
+    depends_on:
+      bigchaindb:
+        condition: service_healthy
   # Build docs only
   # docker-compose build bdocs
   # docker-compose up -d bdocs


### PR DESCRIPTION
Solution: add health check to ensure HTTP API server is running

When we start the system we don't wait for all dependencies to be up and running.