### PR TITLE
Problem: the driver is using an old tendermint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ test: check-deps ## Run all tests once or specify a file/test with TEST=tests/fi
 
 test-watch: check-deps ## Run all, or only one with TEST=tests/file.py::Class::test, tests and wait. Every time you change code, test/s will be run again.
 	@$(DC) run --rm bigchaindb-driver pytest ${TEST} -f -v
-	@$(DC) run --rm bigchaindb-driver pytest ${TEST} -f -v
 
 docs: ## Generate Sphinx HTML documentation, including API docs
 	@$(DC) run --rm --no-deps bdocs make -C docs html
@@ -80,7 +79,6 @@ cov: check-deps ## Check code coverage and open the result in the browser
 
 clean: clean-build clean-pyc clean-test ## Remove all build, test, coverage and Python artifacts
 	@$(ECHO) "Cleaning was successful."
-
 
 release: clean ## Package and upload a release
 	python setup.py sdist upload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,14 +51,14 @@ services:
       retries: 3
     command: bigchaindb -l DEBUG start
   tendermint:
-    image: tendermint/tendermint:0.12
+    image: tendermint/tendermint:0.19.2
     volumes:
       - ./compose/tendermint/tmdata/config.toml:/tendermint/config.toml
     entrypoint: ''
     ports:
       - "46656"
       - "46657"
-    command: bash -c "tendermint init && tendermint node"
+    command: sh -c "tendermint init && tendermint node --proxy_app=tcp://bigchaindb:46658"
   bdb:
     image: busybox
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     ports:
       - "46656"
       - "46657"
-    command: sh -c "tendermint init && tendermint node --proxy_app=tcp://bigchaindb:46658"
+    command: sh -c "tendermint init && tendermint node --consensus.create_empty_blocks=false --proxy_app=tcp://bigchaindb:46658"
   bdb:
     image: busybox
     depends_on:


### PR DESCRIPTION
Solution: upgrade tendermint to match the version the server uses

The server recently upgraded to a newer tendermint version and these changes were not yet reflected in the driver. They also led to problems when using docker.