### PR TITLE
Problem: the default mode of a tx does not match the default of the s…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Afterwards Bob spends 3 of these tokens.
     fulfilled_token_tx = bdb.transactions.fulfill(
         prepared_token_tx,
         private_keys=alice.private_key)
-    bdb.transactions.send(fulfilled_token_tx, mode='commit')
+    bdb.transactions.send_commit(fulfilled_token_tx)
 
     # Use the tokens
     # create the output and inout for the transaction
@@ -123,8 +123,7 @@ Afterwards Bob spends 3 of these tokens.
     fulfilled_transfer_tx = bdb.transactions.fulfill(
         prepared_transfer_tx,
         private_keys=bob.private_key)
-    sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx,
-                                             mode='commit')
+    sent_transfer_tx = bdb.transactions.send_commit(fulfilled_transfer_tx)
 
 Compatibility Matrix
 --------------------

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -1,6 +1,7 @@
 from .transport import Transport
 from .offchain import prepare_transaction, fulfill_transaction
 from .utils import _normalize_nodes
+from warnings import warn
 
 
 class BigchainDB:
@@ -26,8 +27,8 @@ class BigchainDB:
             headers (dict): Optional headers that will be passed with
                 each request. To pass headers only on a per-request
                 basis, you can pass the headers to the method of choice
-                (e.g. :meth:`BigchainDB().transactions.send()
-                <.TransactionsEndpoint.send>`).
+                (e.g. :meth:`BigchainDB().transactions.send_commit()
+                <.TransactionsEndpoint.send_commit>`).
 
         """
         self._nodes = _normalize_nodes(*nodes)
@@ -318,6 +319,41 @@ class TransactionsEndpoint(NamespacedDriver):
         Args:
             transaction (dict): the transaction to be sent
                 to the Federation node(s).
+            mode (str): the mode the transaction is sent to the Federation
+                node(s).
+            headers (dict): Optional headers to pass to the request.
+
+        Returns:
+            dict: The transaction sent to the Federation node(s).
+
+        .. warning::
+
+            The method .send will be deprecated in the next release
+            of the driver, please use ``.send_commit``, ``.send_sync``, or
+            ``.send_async`` instead. More info:
+            https://docs.bigchaindb.com/projects/py-driver/en/latest/handcraft.html#send-the-transaction
+        """
+
+        warn('The method .send will be deprecated in the next release of the '
+             'driver, please use .send_commit, .send_sync, or .send_async '
+             'instead. More info: '
+             'https://docs.bigchaindb.com/projects/py-driver/en/latest/'
+             'handcraft.html#send-the-transaction',
+             PendingDeprecationWarning, stacklevel=2)
+
+        return self.transport.forward_request(
+            method='POST',
+            path=self.path,
+            json=transaction,
+            params={'mode': mode},
+            headers=headers)
+
+    def send_async(self, transaction, headers=None):
+        """Submit a transaction to the Federation with the mode `async`.
+
+        Args:
+            transaction (dict): the transaction to be sent
+                to the Federation node(s).
             headers (dict): Optional headers to pass to the request.
 
         Returns:
@@ -328,7 +364,45 @@ class TransactionsEndpoint(NamespacedDriver):
             method='POST',
             path=self.path,
             json=transaction,
-            params={'mode': mode},
+            params={'mode': 'async'},
+            headers=headers)
+
+    def send_sync(self, transaction, headers=None):
+        """Submit a transaction to the Federation with the mode `sync`.
+
+        Args:
+            transaction (dict): the transaction to be sent
+                to the Federation node(s).
+            headers (dict): Optional headers to pass to the request.
+
+        Returns:
+            dict: The transaction sent to the Federation node(s).
+
+        """
+        return self.transport.forward_request(
+            method='POST',
+            path=self.path,
+            json=transaction,
+            params={'mode': 'sync'},
+            headers=headers)
+
+    def send_commit(self, transaction, headers=None):
+        """Submit a transaction to the Federation with the mode `commit`.
+
+        Args:
+            transaction (dict): the transaction to be sent
+                to the Federation node(s).
+            headers (dict): Optional headers to pass to the request.
+
+        Returns:
+            dict: The transaction sent to the Federation node(s).
+
+        """
+        return self.transport.forward_request(
+            method='POST',
+            path=self.path,
+            json=transaction,
+            params={'mode': 'commit'},
             headers=headers)
 
     def retrieve(self, txid, headers=None):
@@ -476,6 +550,7 @@ class MetadataEndpoint(NamespacedDriver):
         path (str): The path of the endpoint.
 
     """
+
     PATH = '/metadata/'
 
     def get(self, *, search, limit=0, headers=None):

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -83,7 +83,9 @@ backlog where it will be validated before being included in a block.
 
 .. code-block:: python
 
-    >>> sent_tx = bdb.transactions.send(signed_tx)
+    >>> sent_tx = bdb.transactions.send_commit(signed_tx)
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead. `More info`_
 
 Note that the transaction payload returned by the BigchainDB node is equivalent
 to the signed transaction payload.
@@ -112,7 +114,7 @@ Recap: Asset Creation
                               asset=digital_asset_payload)
 
     signed_tx = bdb.transactions.fulfill(tx, private_keys=alice.private_key)
-    sent_tx = bdb.transactions.send(signed_tx)
+    sent_tx = bdb.transactions.send_commit(signed_tx)
     sent_tx == signed_tx
 
 Check if the Transaction was sent successfully
@@ -272,7 +274,9 @@ the need to have a connection to a BigchainDB federation.
 
 .. code-block:: python
 
-    >>> sent_tx_transfer = bdb.transactions.send(signed_tx_transfer)
+    >>> sent_tx_transfer = bdb.transactions.send_commit(signed_tx_transfer)
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead. `More info`_
 
 Again, as with the ``'CREATE'`` transaction, notice how the payload returned
 by the server is equal to the signed one.
@@ -312,7 +316,7 @@ Recap: Asset Transfer
         tx_transfer,
         private_keys=alice.private_key,
     )
-    sent_tx_transfer = bdb.transactions.send(signed_tx_transfer)
+    sent_tx_transfer = bdb.transactions.send_commit(signed_tx_transfer)
 
 Double Spends
 -------------
@@ -358,7 +362,7 @@ specifying the matching `asset_id`.
 
     >>> from bigchaindb_driver.exceptions import BigchaindbException
     >>> try:
-    ...     bdb.transactions.send(fulfilled_tx_transfer_2)
+    ...     bdb.transactions.send_commit(fulfilled_tx_transfer_2)
     ... except BigchaindbException as e:
     ...     print(e.info)
 
@@ -411,10 +415,12 @@ list or tuple of ``recipients``:
 
 .. code-block:: python
 
-    >>> sent_car_tx = bdb.transactions.send(signed_car_creation_tx)
+    >>> sent_car_tx = bdb.transactions.send_commit(signed_car_creation_tx)
 
     >>> sent_car_tx == signed_car_creation_tx
     True
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead. `More info`_
 
 Let's see how the example looks like when ``alice`` and ``bob`` are the issuers:
 
@@ -445,7 +451,7 @@ Let's see how the example looks like when ``alice`` and ``bob`` are the issuers:
         car_creation_tx,
         private_keys=[alice.private_key, bob.private_key],
     )
-    sent_car_tx = bdb.transactions.send(signed_car_creation_tx)
+    sent_car_tx = bdb.transactions.send_commit(signed_car_creation_tx)
 
 
 One day, ``alice`` and ``bob``, having figured out how to teleport themselves,
@@ -542,7 +548,9 @@ Sending the transaction over to a BigchainDB node:
 
 .. code-block:: python
 
-    sent_car_transfer_tx = bdb.transactions.send(signed_car_transfer_tx)
+    sent_car_transfer_tx = bdb.transactions.send_commit(signed_car_transfer_tx)
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead. `More info`_
 
 Done!
 
@@ -1198,3 +1206,5 @@ If you execute in a timely fashion, you should see the following:
 Of course, when the ``execute`` transaction was accepted in-time by bigchaindb,
 then writing the ``abort`` transaction after expiry will yield a
 ``Doublespend`` error.
+
+.. _More info: https://docs.bigchaindb.com/projects/py-driver/en/latest/handcraft.html#send-the-transaction

--- a/docs/handcraft.rst
+++ b/docs/handcraft.rst
@@ -654,18 +654,23 @@ Handcrafting a ``CREATE`` transaction can be done as follows:
 
     handcrafted_creation_tx['id'] = creation_txid
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+send the transaction
+---------------------
+
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
 
 .. code-block:: python
 
     from bigchaindb_driver import BigchainDB
 
     bdb = BigchainDB('http://bdb-server:9984')
-    returned_creation_tx = bdb.transactions.send(handcrafted_creation_tx, mode='sync')
+    returned_creation_tx = bdb.transactions.send_async(handcrafted_creation_tx)
 
 A quick check:
 
@@ -1113,18 +1118,21 @@ In a nutshell
 
     handcrafted_transfer_tx['id'] = transfer_txid
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
+
 
 .. code-block:: python
 
     from bigchaindb_driver import BigchainDB
 
     bdb = BigchainDB('http://bdb-server:9984')
-    returned_transfer_tx = bdb.transactions.send(handcrafted_transfer_tx, mode='sync')
+    returned_transfer_tx = bdb.transactions.send_async(handcrafted_transfer_tx)
 
 A quick check:
 
@@ -1237,18 +1245,20 @@ Handcrafting the ``CREATE`` transaction for our :ref:`bicycle sharing example
     # add the id
     token_creation_tx['id'] = shared_creation_txid
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
 
 .. code-block:: python
 
     from bigchaindb_driver import BigchainDB
 
     bdb = BigchainDB('http://bdb-server:9984')
-    returned_creation_tx = bdb.transactions.send(token_creation_tx, mode='sync')
+    returned_creation_tx = bdb.transactions.send_async(token_creation_tx)
 
 A few checks:
 
@@ -1368,18 +1378,20 @@ to Bob:
     # add the id
     token_transfer_tx['id'] = shared_transfer_txid
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
 
 .. code-block:: python
 
     from bigchaindb_driver import BigchainDB
 
     bdb = BigchainDB('http://bdb-server:9984')
-    returned_transfer_tx = bdb.transactions.send(token_transfer_tx, mode='sync')
+    returned_transfer_tx = bdb.transactions.send_async(token_transfer_tx)
 
 A few checks:
 
@@ -1438,15 +1450,17 @@ Say ``alice`` and ``bob`` own a car together:
 
     In [0]: signed_car_creation_tx
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
 
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
+
 .. code-block:: python
 
-    sent_car_tx = bdb.transactions.send(signed_car_creation_tx, mode='sync')
+    sent_car_tx = bdb.transactions.send_async(signed_car_creation_tx)
 
 One day, ``alice`` and ``bob``, having figured out how to teleport themselves,
 and realizing they no longer need their car, wish to transfer the ownership of
@@ -1486,7 +1500,7 @@ their car over to ``carol``:
 
 .. code-block:: python
 
-    sent_car_transfer_tx = bdb.transactions.send(signed_car_transfer_tx, mode='sync')
+    sent_car_transfer_tx = bdb.transactions.send_async(signed_car_transfer_tx)
 
 Doing this manually
 -------------------
@@ -1871,18 +1885,20 @@ Handcrafting the ``'CREATE'`` transaction
     # add the id
     handcrafted_car_creation_tx['id'] = car_creation_txid
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
 
 .. code-block:: python
 
     from bigchaindb_driver import BigchainDB
 
     bdb = BigchainDB('http://bdb-server:9984')
-    returned_car_creation_tx = bdb.transactions.send(handcrafted_car_creation_tx, mode='sync')
+    returned_car_creation_tx = bdb.transactions.send_async(handcrafted_car_creation_tx)
 
 
 Handcrafting the ``'TRANSFER'`` transaction
@@ -1978,16 +1994,19 @@ Handcrafting the ``'TRANSFER'`` transaction
 
     handcrafted_car_transfer_tx['id'] = car_transfer_txid
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
+
 
 .. code-block:: python
 
     bdb = BigchainDB('http://bdb-server:9984')
-    returned_car_transfer_tx = bdb.transactions.send(handcrafted_car_transfer_tx, mode='sync')
+    returned_car_transfer_tx = bdb.transactions.send_async(handcrafted_car_transfer_tx)
 
 
 **************************************
@@ -2124,18 +2143,20 @@ Handcrafting the ``'CREATE'`` transaction
     # add the id
     handcrafted_car_creation_tx['id'] = car_creation_txid
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
 
 .. code-block:: python
 
     from bigchaindb_driver import BigchainDB
 
     bdb = BigchainDB('http://bdb-server:9984')
-    returned_car_creation_tx = bdb.transactions.send(handcrafted_car_creation_tx, mode='sync')
+    returned_car_creation_tx = bdb.transactions.send_async(handcrafted_car_creation_tx)
 
 
 
@@ -2229,16 +2250,18 @@ Handcrafting the ``'TRANSFER'`` transaction
 
     handcrafted_car_transfer_tx['id'] = car_transfer_txid
 
-To send it over to BigchainDB we have different options. A `mode` parameter can be used to change the broadcasting API
-used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
-By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is
+To send it over to BigchainDB we have different options. You can chose from three different methods to change the
+broadcasting API used in `Tendermint <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_.
+By choosing a mode, a new transaction can be pushed with a different mode. The recommended mode for basic usages is
 ``commit``, which will wait until the transaction is committed to a block or a timeout is reached. The ``sync`` mode
 will return after the transaction is validated, while ``async`` will return right away.
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead.
 
 .. code-block:: python
 
     bdb = BigchainDB('http://bdb-server:9984')
-    returned_car_transfer_tx = bdb.transactions.send(handcrafted_car_transfer_tx, mode='sync')
+    returned_car_transfer_tx = bdb.transactions.send_async(handcrafted_car_transfer_tx)
 
 
 .. _sha3: https://github.com/tiran/pysha3

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -123,7 +123,9 @@ And sent over to a BigchainDB node:
 
 .. code-block:: python
 
-    >>> sent_creation_tx = bdb.transactions.send(fulfilled_creation_tx)
+    >>> sent_creation_tx = bdb.transactions.send_commit(fulfilled_creation_tx)
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead. `More info`_
 
 Note that the response from the node should be the same as that which was sent:
 
@@ -242,10 +244,12 @@ and finally send it to the connected BigchainDB node:
 
 .. code-block:: python
 
-    >>> sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx)
+    >>> sent_transfer_tx = bdb.transactions.send_commit(fulfilled_transfer_tx)
 
     >>> sent_transfer_tx == fulfilled_transfer_tx
     True
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead. `More info`_
 
 Bob is the new owner:
 
@@ -317,7 +321,7 @@ Recap: Asset Creation & Transfer
         private_keys=alice.private_key
     )
 
-    sent_creation_tx = bdb.transactions.send(fulfilled_creation_tx)
+    sent_creation_tx = bdb.transactions.send_commit(fulfilled_creation_tx)
 
     txid = fulfilled_creation_tx['id']
 
@@ -351,7 +355,7 @@ Recap: Asset Creation & Transfer
         private_keys=alice.private_key,
     )
 
-    sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx)
+    sent_transfer_tx = bdb.transactions.send_commit(fulfilled_transfer_tx)
 
     print("Is Bob the owner?",
         sent_transfer_tx['outputs'][0]['public_keys'][0] == bob.public_key)
@@ -416,10 +420,12 @@ Sending the transaction:
 
 .. code-block:: python
 
-    >>> sent_token_tx = bdb.transactions.send(fulfilled_token_tx)
+    >>> sent_token_tx = bdb.transactions.send_commit(fulfilled_token_tx)
 
     >>> sent_token_tx == fulfilled_token_tx
     True
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead. `More info`_
 
 .. note:: Defining ``recipients``:
 
@@ -507,10 +513,12 @@ The ``fulfilled_transfer_tx`` dictionary should have two outputs, one with
 
 .. code-block:: python
 
-    >>> sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx)
+    >>> sent_transfer_tx = bdb.transactions.send_commit(fulfilled_transfer_tx)
 
     >>> sent_transfer_tx == fulfilled_transfer_tx
     True
+
+.. warning:: The method .send will be deprecated in the next release of the driver, please use ``.send_commit``, ``.send_sync``, or ``.send_async`` instead. `More info`_
 
 .. _query-for-assets:
 
@@ -548,7 +556,7 @@ Let's create 3 assets:
     )
     fulfilled_creation_tx = bdb.transactions.fulfill(
         prepared_creation_tx, private_keys=alice.private_key)
-    bdb.transactions.send(fulfilled_creation_tx)
+    bdb.transactions.send_commit(fulfilled_creation_tx)
 
     prepared_creation_tx = bdb.transactions.prepare(
         operation='CREATE',
@@ -557,7 +565,7 @@ Let's create 3 assets:
     )
     fulfilled_creation_tx = bdb.transactions.fulfill(
         prepared_creation_tx, private_keys=alice.private_key)
-    bdb.transactions.send(fulfilled_creation_tx)
+    bdb.transactions.send_commit(fulfilled_creation_tx)
 
     prepared_creation_tx = bdb.transactions.prepare(
         operation='CREATE',
@@ -566,7 +574,7 @@ Let's create 3 assets:
     )
     fulfilled_creation_tx = bdb.transactions.fulfill(
         prepared_creation_tx, private_keys=alice.private_key)
-    bdb.transactions.send(fulfilled_creation_tx)
+    bdb.transactions.send_commit(fulfilled_creation_tx)
 
 Let's perform a text search for all assets that contain the word ``bigchaindb``:
 
@@ -742,3 +750,5 @@ argument:
             'metadata': {'planet': 'earth'}
         }
     ]
+
+.. _More info: https://docs.bigchaindb.com/projects/py-driver/en/latest/handcraft.html#send-the-transaction

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,8 @@ from cryptoconditions import Ed25519Sha256
 from pytest import fixture
 from sha3 import sha3_256
 
-from bigchaindb_driver.common.transaction import Transaction, _fulfillment_to_details
+from bigchaindb_driver.common.transaction import Transaction, \
+    _fulfillment_to_details
 
 
 # FIXME The sleep, or some other approach is required to wait for the
@@ -243,8 +244,22 @@ def persisted_alice_transaction(signed_alice_transaction,
 
 @fixture
 def persisted_random_transaction(alice_pubkey,
-                                 alice_privkey,
-                                 transactions_api_full_url):
+                                 alice_privkey):
+    from uuid import uuid4
+    from bigchaindb_driver.common.transaction import Transaction
+    asset = {'data': {'x': str(uuid4())}}
+    tx = Transaction.create(
+        tx_signers=[alice_pubkey],
+        recipients=[([alice_pubkey], 1)],
+        asset=asset,
+    )
+    return tx.sign([alice_privkey]).to_dict()
+
+
+@fixture
+def sent_persisted_random_transaction(alice_pubkey,
+                                      alice_privkey,
+                                      transactions_api_full_url):
     from uuid import uuid4
     from bigchaindb_driver.common.transaction import Transaction
     asset = {'data': {'x': str(uuid4())}}
@@ -260,11 +275,11 @@ def persisted_random_transaction(alice_pubkey,
 
 
 @fixture
-def block_with_alice_transaction(persisted_random_transaction,
+def block_with_alice_transaction(sent_persisted_random_transaction,
                                  blocks_api_full_url):
     return requests.get(
         blocks_api_full_url,
-        params={'transaction_id': persisted_random_transaction['id']}
+        params={'transaction_id': sent_persisted_random_transaction['id']}
     ).json()[0]
 
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -52,8 +52,8 @@ class TestBigchainDB:
 
 class TestTransactionsEndpoint:
 
-    def test_retrieve(self, driver, persisted_random_transaction):
-        txid = persisted_random_transaction['id']
+    def test_retrieve(self, driver, sent_persisted_random_transaction):
+        txid = sent_persisted_random_transaction['id']
         tx = driver.transactions.retrieve(txid)
         assert tx['id'] == txid
 
@@ -100,32 +100,21 @@ class TestTransactionsEndpoint:
         fulfillment_uri = ed25519.serialize_uri()
         assert signed_transaction['inputs'][0]['fulfillment'] == fulfillment_uri   # noqa
 
-    def test_send(self, driver, alice_privkey, unsigned_transaction):
-        fulfilled_tx = driver.transactions.fulfill(unsigned_transaction,
-                                                   private_keys=alice_privkey)
-        sent_tx = driver.transactions.send(fulfilled_tx)
-        assert sent_tx == fulfilled_tx
+    def test_send(self, driver, persisted_random_transaction):
+        sent_tx = driver.transactions.send(persisted_random_transaction)
+        assert sent_tx == persisted_random_transaction
 
-    def test_send_wrong_mode(self, driver,
-                             alice_privkey, unsigned_transaction):
-        from bigchaindb_driver.exceptions import BadRequest
-        fulfilled_tx = driver.transactions.fulfill(unsigned_transaction,
-                                                   private_keys=alice_privkey)
-        with raises(BadRequest) as error:
-            driver.transactions.send(fulfilled_tx, mode='mode')
-            assert error.exception.message == \
-                'Mode must be "async", "sync" or "commit"'
+    def test_send_commit(self, driver, persisted_random_transaction):
+        sent_tx = driver.transactions.send_commit(persisted_random_transaction)
+        assert sent_tx == persisted_random_transaction
 
-    @mark.skip(reason='transactions are not yet unique')
-    @mark.parametrize('mode_params', (
-        'sync', 'commit'
-    ))
-    def test_send_with_mode(self, driver, alice_privkey,
-                            unsigned_transaction, mode_params):
-        fulfilled_tx = driver.transactions.fulfill(unsigned_transaction,
-                                                   private_keys=alice_privkey)
-        sent_tx = driver.transactions.send(fulfilled_tx, mode=mode_params)
-        assert sent_tx == fulfilled_tx
+    def test_send_async(self, driver, persisted_random_transaction):
+        sent_tx = driver.transactions.send_async(persisted_random_transaction)
+        assert sent_tx == persisted_random_transaction
+
+    def test_send_sync(self, driver, persisted_random_transaction):
+        sent_tx = driver.transactions.send_sync(persisted_random_transaction)
+        assert sent_tx == persisted_random_transaction
 
     def test_get_raises_type_error(self, driver):
         """This test is somewhat important as it ensures that the
@@ -213,8 +202,9 @@ class TestOutputsEndpoint:
 
 class TestBlocksEndppoint:
 
-    def test_get(self, driver, persisted_random_transaction):
-        block_id = driver.blocks.get(txid=persisted_random_transaction['id'])
+    def test_get(self, driver, sent_persisted_random_transaction):
+        block_id = driver.blocks.\
+            get(txid=sent_persisted_random_transaction['id'])
         assert block_id
 
     def test_retrieve(self, driver, block_with_alice_transaction):


### PR DESCRIPTION
…erver

Solution: remove the default mode and add a method for each mode

- added deprecation warning for `send`
- added a method for each mode
- updated tests and docs
- changed one fixture and added another to have more unique transactions. Otherwise I would have not been able to run the tests for the mode (yay)

(darn it, my Problem statement is too long)

Resolves #431 