### PR TITLE
Problem: info endpoint does not return keyrings

### DIFF
--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -99,8 +99,8 @@ class BigchainDB:
             dict: Details of the node that this instance is connected
             to. Some information that may be interesting:
 
-                * the server version,
-                * the public key of the node, and
+                * the server version and
+                * an overview of all the endpoints
 
         Note:
             Currently limited to one node, and will be expanded to

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -101,8 +101,6 @@ class BigchainDB:
 
                 * the server version,
                 * the public key of the node, and
-                * its key ring (list of public keys of the nodes this
-                  node is connected to).
 
         Note:
             Currently limited to one node, and will be expanded to

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -38,7 +38,6 @@ class TestBigchainDB:
         response = driver.info()
         assert 'api' in response
         assert 'docs' in response
-        assert response['keyring'] == []
         assert response['software'] == 'BigchainDB'
         assert 'version' in response
 


### PR DESCRIPTION
Solution: remove keyrings from tests and docs
