### PR TITLE
Problem: common code is not tested

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 source = .
-omit = *test*, docs/*, setup.py
+omit = *test*, docs/*, bigchaindb_driver/common/*, setup.py

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,10 @@ codecov:
 coverage:
   range: "95...100"
 
-  ignore:
-    - "docs/*"
-    - "tests/*"
+ignore:
+  - "docs/*"
+  - "tests/*"
+  - "bigchaindb_driver/common/*"
 
 comment:
   layout: "header, diff, changes, sunburst, uncovered"


### PR DESCRIPTION
Solution: remove it from codecov
The `common` package is checked in codecov but the tests were not included when it was copied from `bigchaindb`. Since there will be a new solution for `common` soon, the tests will not be copied and  it'll just be ignored by codecov.