### PR TITLE
Problem: KeypairNotFoundException does not exist anymore

### DIFF
--- a/bigchaindb_driver/common/exceptions.py
+++ b/bigchaindb_driver/common/exceptions.py
@@ -38,10 +38,6 @@ class CyclicBlockchainError(BigchainDBError):
     """Raised when there is a cycle in the blockchain"""
 
 
-class KeypairNotFoundException(BigchainDBError):
-    """Raised if operation cannot proceed because the keypair was not given"""
-
-
 class KeypairMismatchException(BigchainDBError):
     """Raised if the private key(s) provided for signing don't match any of the
     current owner(s)


### PR DESCRIPTION
Solution: remove KeypairNotFoundException

The exception was removed in the [bigchaindb repository](https://github.com/bigchaindb/bigchaindb/commit/2b39566a4b93fe6a95356b2d350326ff049ce825#diff-c03138cb428bd41d7c7bf527924b3d5c)