### PR TITLE
Problem: The round robin strategy has issues.

### DIFF
--- a/bigchaindb_driver/connection.py
+++ b/bigchaindb_driver/connection.py
@@ -1,15 +1,21 @@
+import time
+
 from collections import namedtuple
+from datetime import datetime, timedelta
 
 from requests import Session
+from requests.exceptions import ConnectionError
 
 from .exceptions import HTTP_EXCEPTIONS, TransportError
 
+
+BACKOFF_DELAY = 0.5  # seconds
 
 HttpResponse = namedtuple('HttpResponse', ('status_code', 'headers', 'data'))
 
 
 class Connection:
-    """A Connection object to make HTTP requests."""
+    """A Connection object to make HTTP requests to a particular node."""
 
     def __init__(self, *, node_url, headers=None):
         """Initializes a :class:`~bigchaindb_driver.connection.Connection`
@@ -25,29 +31,72 @@ class Connection:
         if headers:
             self.session.headers.update(headers)
 
-    def request(self, method, timeout=None, *, path=None, json=None,
-                params=None, headers=None, **kwargs):
+        self._retries = 0
+        self.backoff_time = None
+
+    def request(self, method, *, path=None, json=None,
+                params=None, headers=None, timeout=None, **kwargs):
         """Performs an HTTP requests for the specified arguments.
+
+           If the node has backoff time attached, waits till the time is due.
+
+           Backoff time is adjusted after the request is made.
 
         Args:
             method (str): HTTP method (e.g.: ``'GET'``).
             path (str): API endpoint path (e.g.: ``'/transactions'``).
             json (dict): JSON data to send along with the request.
-            params (dict)): Dictionary of URL (query) parameters.
+            params (dict): Dictionary of URL (query) parameters.
             headers (dict): Optional headers to pass to the request.
+            timeout (int): Optional timeout in seconds.
             kwargs: Optional keyword arguments.
 
         """
-        url = self.node_url + path if path else self.node_url
-        response = self.session.request(
-            method=method,
-            timeout=timeout,
-            url=url,
-            json=json,
-            params=params,
-            headers=headers,
-            **kwargs
-        )
+        backoff_timedelta = self.get_backoff_timedelta()
+
+        if timeout is not None and timeout < backoff_timedelta:
+            raise TimeoutError
+
+        if backoff_timedelta > 0:
+            time.sleep(backoff_timedelta)
+
+        connExc = None
+        timeout = timeout if timeout is None else timeout - backoff_timedelta
+        try:
+            response = self._request(
+                method=method,
+                timeout=timeout,
+                url=self.node_url + path if path else self.node_url,
+                json=json,
+                params=params,
+                headers=headers,
+                **kwargs,
+            )
+        except ConnectionError as err:
+            connExc = err
+            raise err
+        finally:
+            self.update_backoff_time(success=connExc is None)
+        return response
+
+    def get_backoff_timedelta(self, timeout=None):
+        if self.backoff_time is None:
+            return 0
+
+        return (self.backoff_time - datetime.utcnow()).total_seconds()
+
+    def update_backoff_time(self, success):
+        if success:
+            self._retries = 0
+            self.backoff_time = None
+        else:
+            utcnow = datetime.utcnow()
+            backoff_delta = BACKOFF_DELAY * 2 ** self._retries
+            self.backoff_time = utcnow + timedelta(seconds=backoff_delta)
+            self._retries += 1
+
+    def _request(self, **kwargs):
+        response = self.session.request(**kwargs)
         text = response.text
         try:
             json = response.json()
@@ -55,6 +104,6 @@ class Connection:
             json = None
         if not (200 <= response.status_code < 300):
             exc_cls = HTTP_EXCEPTIONS.get(response.status_code, TransportError)
-            raise exc_cls(response.status_code, text, json, url)
+            raise exc_cls(response.status_code, text, json, kwargs['url'])
         data = json if json is not None else text
         return HttpResponse(response.status_code, response.headers, data)

--- a/bigchaindb_driver/connection.py
+++ b/bigchaindb_driver/connection.py
@@ -79,7 +79,7 @@ class Connection:
             self.update_backoff_time(success=connExc is None)
         return response
 
-    def get_backoff_timedelta(self, timeout=None):
+    def get_backoff_timedelta(self):
         if self.backoff_time is None:
             return 0
 

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -23,7 +23,7 @@ class BigchainDB:
                Currently, the full URL must be given. In the absence of any
                node, the default(``'http://localhost:9984'``) will be used.
                If node is passed as a dict, `endpoint` is a required key;
-              `headers` is an optional `dict` of headers.
+               `headers` is an optional `dict` of headers.
                transport_class: Optional transport class to use.
                Defaults to :class:`~bigchaindb_driver.transport.Transport`.
              headers (dict): Optional headers that will be passed with

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -18,21 +18,21 @@ class BigchainDB:
                  headers=None, timeout=None):
         """Initialize a :class:`~bigchaindb_driver.BigchainDB` driver instance.
 
-           Args:
-             *nodes (list of (str or dict)): BigchainDB nodes to connect to.
-               Currently, the full URL must be given. In the absence of any
-               node, the default(``'http://localhost:9984'``) will be used.
-               If node is passed as a dict, `endpoint` is a required key;
-               `headers` is an optional `dict` of headers.
-               transport_class: Optional transport class to use.
-               Defaults to :class:`~bigchaindb_driver.transport.Transport`.
-             headers (dict): Optional headers that will be passed with
-               each request. To pass headers only on a per-request
-               basis, you can pass the headers to the method of choice
-               (e.g. :meth:`BigchainDB().transactions.send_commit()
-               <.TransactionsEndpoint.send_commit>`).
-             timeout (int): Optional timeout in seconds that will be passed
-               to each request.
+        Args:
+            *nodes (list of (str or dict)): BigchainDB nodes to connect to.
+                Currently, the full URL must be given. In the absence of any
+                node, the default(``'http://localhost:9984'``) will be used.
+                If node is passed as a dict, `endpoint` is a required key;
+                `headers` is an optional `dict` of headers.
+            transport_class: Optional transport class to use.
+                Defaults to :class:`~bigchaindb_driver.transport.Transport`.
+            headers (dict): Optional headers that will be passed with
+                each request. To pass headers only on a per-request
+                basis, you can pass the headers to the method of choice
+                (e.g. :meth:`BigchainDB().transactions.send_commit()
+                <.TransactionsEndpoint.send_commit>`).
+            timeout (int): Optional timeout in seconds that will be passed
+                to each request.
         """
         self._nodes = normalize_nodes(*nodes, headers=headers)
         self._transport = transport_class(*self._nodes, timeout=timeout)

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -1,40 +1,40 @@
 from .transport import Transport
 from .offchain import prepare_transaction, fulfill_transaction
-from .utils import _normalize_nodes
+from .utils import normalize_nodes
 from warnings import warn
 
 
 class BigchainDB:
-    """BigchainDB driver class.
+    """A :class:`~bigchaindb_driver.BigchainDB` driver is able to create, sign,
+       and submit transactions to one or more nodes in a Federation.
 
-    A :class:`~bigchaindb_driver.BigchainDB` driver is able to create, sign,
-    and submit transactions to one or more nodes in a Federation.
+       If initialized with ``>1`` nodes, the driver will send successive
+       requests to different nodes in a round-robin fashion (this will be
+       customizable in the future).
 
-    If initialized with ``>1`` nodes, the driver will send successive requests
-    to different nodes in a round-robin fashion (this will be customizable in
-    the future).
     """
 
-    def __init__(self, *nodes, timeout=20,
-                 transport_class=Transport, headers=None):
+    def __init__(self, *nodes, transport_class=Transport,
+                 headers=None, timeout=None):
         """Initialize a :class:`~bigchaindb_driver.BigchainDB` driver instance.
 
-        Args:
-            *nodes (str): BigchainDB nodes to connect to. Currently, the full
-                URL must be given. In the absence of any node, the default
-                (``'http://localhost:9984'``) will be used.
-            timeout (int): timeout in seconds, specify how long to wait for
-                the response. default value is 20 secs.
-            transport_class: Optional transport class to use.
-                Defaults to :class:`~bigchaindb_driver.transport.Transport`.
-            headers (dict): Optional headers that will be passed with
-                each request. To pass headers only on a per-request
-                basis, you can pass the headers to the method of choice
-                (e.g. :meth:`BigchainDB().transactions.send_commit()
-                <.TransactionsEndpoint.send_commit>`).
-
+           Args:
+             *nodes (list of (str or dict)): BigchainDB nodes to connect to.
+               Currently, the full URL must be given. In the absence of any
+               node, the default(``'http://localhost:9984'``) will be used.
+               If node is passed as a dict, `endpoint` is a required key;
+              `headers` is an optional `dict` of headers.
+               transport_class: Optional transport class to use.
+               Defaults to :class:`~bigchaindb_driver.transport.Transport`.
+             headers (dict): Optional headers that will be passed with
+               each request. To pass headers only on a per-request
+               basis, you can pass the headers to the method of choice
+               (e.g. :meth:`BigchainDB().transactions.send_commit()
+               <.TransactionsEndpoint.send_commit>`).
+             timeout (int): Optional timeout in seconds that will be passed
+               to each request.
         """
-        self._nodes = _normalize_nodes(*nodes, headers=headers)
+        self._nodes = normalize_nodes(*nodes, headers=headers)
         self._transport = transport_class(*self._nodes, timeout=timeout)
         self._transactions = TransactionsEndpoint(self)
         self._outputs = OutputsEndpoint(self)

--- a/bigchaindb_driver/exceptions.py
+++ b/bigchaindb_driver/exceptions.py
@@ -23,16 +23,13 @@ class MissingPrivateKeyError(BigchaindbException):
     """Raised if a private key is missing."""
 
 
-class TimeoutException(BigchaindbException):
-    """Raised if round robin strategy failed with timeout"""
+class TimeoutError(BigchaindbException):
+    """Raised if the request algorithm times out."""
 
     @property
-    def info(self):
+    def connection_errors(self):
+        """Returns connection errors occurred before timeout expired."""
         return self.args[0]
-
-    @property
-    def errors(self):
-        return self.args[1]
 
 
 class TransportError(BigchaindbException):

--- a/bigchaindb_driver/pool.py
+++ b/bigchaindb_driver/pool.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from datetime import datetime, timedelta
+from datetime import datetime
 
 
 class AbstractPicker(metaclass=ABCMeta):
@@ -20,47 +20,32 @@ class AbstractPicker(metaclass=ABCMeta):
 
 
 class RoundRobinPicker(AbstractPicker):
-    """Object to pick a :class:`~bigchaindb_driver.connection.Connection`
-    instance from a list of connections.
-
-    Attributes:
-        picked (str): List index of
-            :class:`~bigchaindb_driver.connection.Connection`
-            instance that has been picked.
+    """Picks a :class:`~bigchaindb_driver.connection.Connection`
+       instance from a list of connections.
 
     """
 
-    def __init__(self):
-        """Initializes a :class:`~bigchaindb_driver.pool.RoundRobinPicker`
-        instance. Sets :attr:`picked` to ``0``.
+    def pick(self, connections):
+        """Picks a connection with the earliest backoff time.
 
-        """
-        self.picked = 0
-
-    def next_node(self, connections):
-        """Update index of the current active node in the pool"""
-        self.picked = (self.picked + 1) % len(connections)
-
-    def pick(self, connections, time_left):
-        """Picks a :class:`~bigchaindb_driver.connection.Connection`
-        instance from the given list of
-        :class:`~bigchaindb_driver.connection.Connection` instances.
+           As a result, the first connection is picked
+           for as long as it has no backoff time.
+           Otherwise, the connections are tried in a round robin fashion.
 
         Args:
-            connections (List): List of
+            connections (:obj:list): List of
                 :class:`~bigchaindb_driver.connection.Connection` instances.
-            time_left: user specified timeout
 
         """
+        if len(connections) == 1:
+            return connections[0]
 
-        current_time_ms = datetime.utcnow()
+        def key(conn):
+            return (datetime.min
+                    if conn.backoff_time is None
+                    else conn.backoff_time)
 
-        while (current_time_ms <= time_left
-                and current_time_ms <= connections[self.picked]['time']):
-            self.next_node(connections)
-            current_time_ms = datetime.utcnow()
-
-        return connections[self.picked]
+        return min(*connections, key=key)
 
 
 class Pool:
@@ -75,39 +60,14 @@ class Pool:
 
         """
         self.connections = connections
-        self.node_count = len(self.connections)
-        self.max_retries = 10
-        self.retries = {
-            key: 0 for key in range(self.node_count)
-        }
         self.picker = picker_class()
-        self.initial_delay = 1
 
-    def update_retries(self, node):
-        """Update retries left of the current node"""
-        self.retries[node] = min(self.retries[node] + 1, self.max_retries)
-
-    def fail_node(self):
-        """Send a message to the pool indicating the connection
-        to the current node is failing and needs to try another one
-        """
-        failing_node = self.picker.picked
-        self.update_retries(failing_node)
-        delta = timedelta(
-            seconds=self.initial_delay * 2 ** self.retries[failing_node])
-        self.connections[failing_node]["time"] = datetime.utcnow() + delta
-        self.picker.next_node(self.connections)
-
-    def get_connection(self, time_left):
+    def get_connection(self):
         """Gets a :class:`~bigchaindb_driver.connection.Connection`
         instance from the pool.
-        Args:
-            time_left: user specified timeout
 
         Returns:
             A :class:`~bigchaindb_driver.connection.Connection` instance.
 
         """
-        connection = self.picker.pick(self.connections,
-                                      datetime.utcnow() + time_left)
-        return connection["node"]
+        return self.picker.pick(self.connections)

--- a/bigchaindb_driver/transport.py
+++ b/bigchaindb_driver/transport.py
@@ -12,15 +12,13 @@ class Transport:
 
     """
 
-    def __init__(self, *nodes, headers=None, timeout=None):
+    def __init__(self, *nodes, timeout=None):
         """Initializes an instance of
         :class:`~bigchaindb_driver.transport.Transport`.
 
         Args:
-            nodes: nodes
-            headers (dict): Optional headers to pass to the
-                :class:`~.connection.Connection` instances, which will
-                add it to the headers to be sent with each request.
+            nodes: each node is a dictionaty with the keys `endpoint` and
+                   `headers`
             timeout (int): Optional timeout in seconds.
 
         """

--- a/bigchaindb_driver/transport.py
+++ b/bigchaindb_driver/transport.py
@@ -17,7 +17,7 @@ class Transport:
         :class:`~bigchaindb_driver.transport.Transport`.
 
         Args:
-            nodes: each node is a dictionaty with the keys `endpoint` and
+            nodes: each node is a dictionary with the keys `endpoint` and
                    `headers`
             timeout (int): Optional timeout in seconds.
 
@@ -38,9 +38,9 @@ class Transport:
            by catching the corresponding
            exceptions and retrying `forward_request`.
 
-           Backoff time is tracked for every configured node.
-           Exponential backoff thus
-           works no matter how many times `forward_request` is called.
+           Exponential backoff is implemented individually for each node.
+           Backoff delays are expressed as timestamps stored on the object and
+           they are not reset in between multiple function calls.
 
            Times out when `self.timeout` is expired, if not `None`.
 

--- a/bigchaindb_driver/transport.py
+++ b/bigchaindb_driver/transport.py
@@ -1,50 +1,50 @@
-from .connection import Connection
-from .pool import Pool
-from .exceptions import TimeoutException, TransportError
-from datetime import datetime, timedelta
 from time import time
+
+from requests.exceptions import ConnectionError
+
+from .connection import Connection
+from .exceptions import TimeoutError
+from .pool import Pool
 
 
 class Transport:
-    """Transport class."""
+    """Transport class.
 
-    def __init__(self, *nodes, timeout=None, headers=None):
+    """
+
+    def __init__(self, *nodes, headers=None, timeout=None):
         """Initializes an instance of
         :class:`~bigchaindb_driver.transport.Transport`.
 
         Args:
             nodes: nodes
-            timeout: timeout
             headers (dict): Optional headers to pass to the
                 :class:`~.connection.Connection` instances, which will
                 add it to the headers to be sent with each request.
+            timeout (int): Optional timeout in seconds.
 
         """
         self.nodes = nodes
         self.timeout = timeout
-        self.init_pool(nodes)
-
-    def init_pool(self, nodes):
-        """Initializes the pool of connections."""
-        connections = [
-            {
-                "node": Connection(
-                    node_url=node["endpoint"],
-                    headers=node["headers"]),
-                "time":datetime.utcnow()} for node in nodes]
-        self.pool = Pool(connections)
-
-    def get_connection(self, time_left):
-        """Gets a connection from the pool.
-
-        Returns:
-            A :class:`~bigchaindb_driver.connection.Connection` instance.
-        """
-        return self.pool.get_connection(time_left)
+        self.connection_pool = Pool([Connection(node_url=node['endpoint'],
+                                                headers=node['headers'])
+                                     for node in nodes])
 
     def forward_request(self, method, path=None,
                         json=None, params=None, headers=None):
-        """Forwards an http request to a connection.
+        """Makes HTTP requests to the configured nodes.
+
+           Retries connection errors
+           (e.g. DNS failures, refused connection, etc).
+           A user may choose to retry other errors
+           by catching the corresponding
+           exceptions and retrying `forward_request`.
+
+           Backoff time is tracked for every configured node.
+           Exponential backoff thus
+           works no matter how many times `forward_request` is called.
+
+           Times out when `self.timeout` is expired, if not `None`.
 
         Args:
             method (str): HTTP method name (e.g.: ``'GET'``).
@@ -58,36 +58,29 @@ class Transport:
             dict: Result of :meth:`requests.models.Response.json`
 
         """
+        error_trace = []
+        timeout = self.timeout
+        while timeout is None or timeout > 0:
+            connection = self.connection_pool.get_connection()
 
-        time_left = timedelta(seconds=self.timeout)
-        start = time()
-        exceptions = {}
-        while time_left.total_seconds() > 0:
+            start = time()
             try:
-                connection = self.get_connection(time_left)
                 response = connection.request(
                     method=method,
-                    timeout=time_left.seconds,
                     path=path,
                     params=params,
                     json=json,
-                    headers=headers
+                    headers=headers,
+                    timeout=timeout,
                 )
+            except ConnectionError as err:
+                error_trace.append(err)
+                continue
+            else:
                 return response.data
-            except TransportError as err:
-                end = time()
-                time_left -= timedelta(seconds=end - start)
-                self.pool.fail_node()
-                start = time()
-                exceptions[err.url] = (err.status_code, err.info)
-            except BaseException as err:
-                end = time()
-                time_left -= timedelta(seconds=end - start)
-                self.pool.fail_node()
-                start = time()
-                node = self.pool.picker.picked
-                exceptions[node] = err
-        if len(exceptions):
-            raise TimeoutException("Request timed out", exceptions)
-        else:
-            raise TimeoutException("Request timed out", None)
+            finally:
+                elapsed = time() - start
+                if timeout is not None:
+                    timeout -= elapsed
+
+        raise TimeoutError(error_trace)

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -20,24 +20,55 @@ and :doc:`you have determined the BigchainDB Root URL <connect>`
 of the node or cluster you want to connect to.
 
 
-Getting Started
----------------
+Connect to Multiple Nodes
+-------------------------
 
-We begin by creating an object of class BigchainDB:
+You can optionally configure multiple nodes to connect to.
 
 .. ipython::
 
     In [0]: from bigchaindb_driver import BigchainDB
 
-    In [0]: bdb_root_url = 'https://example.com:9984'  # Use YOUR BigchainDB Root URL here
+    In [0]: first_node = 'https://first.example.com:9984'
 
-    In [0]: bdb = BigchainDB(bdb_root_url)
+    In [0]: second_node = 'https://second.example.com:9984'
 
-That last command instantiates an object ``bdb`` of class
-:class:`~bigchaindb_driver.BigchainDB`. When instantiating a
-:class:`~bigchaindb_driver.BigchainDB` object without arguments, it
-uses the default BigchainDB Root URL ``http://localhost:9984``.
+    In [0]: headers = {'app_id': 'your_app_id', 'app_key': 'your_app_key'}
 
+    In [0]: bdb = BigchainDB(first_node, second_node, headers=headers)
+
+Each node can have its specific headers in addition to headers specified for all nodes, if any.
+
+.. ipython::
+
+    In [0]: first_node = 'https://first.example.com:9984'
+
+    In [0]: second_node = 'https://second.example.com:9984'
+
+    In [0]: common_headers = {'app_id': 'your_app_id', 'app_key': 'your_app_key'}
+
+    In [0]: second_node_headers = {'node_header': 'node_header_value'}
+
+    In [0]: bdb = BigchainDB(first_node,
+       ...:                  {'endpoint': second_node, 'headers': second_node_headers},
+       ...:                  headers=common_headers)
+
+The driver switches nodes on connection failures in a round robin fashion. Connection failures are intermittent network issues like DNS failures or "refused connection" errors.
+
+The driver switches nodes and repeats requests until the specified timeout is expired. The default timeout is 20
+seconds. When timeout expires, an instance of ``bigchaindb_driver.exceptions.TimeoutError`` is raised. Specify
+``timeout=None`` to repeat connection errors indefinitely.
+
+.. ipython::
+
+    In [0]: bdb = BigchainDB(first_node, second_node, headers=headers, timeout=None)
+
+Also, the driver takes care of the exponential backoff. If a connection error occurs, the driver ensures at least half
+of a second is passed before the request to the same node is repeated. The intervals increase exponentially when
+multiple connection errors occur
+in a row. The user-specified timeout is always respected.
+
+.. warning:: Every node the driver communicates with is supposed to be trusted. The driver does not currently implement any light client protocols.
 
 Create a Digital Asset
 ----------------------

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,15 +1,34 @@
 def test_get_connection():
-    from datetime import datetime, timedelta
-    from bigchaindb_driver.pool import Pool
-    connections = [{"node": 0, "time": datetime.now()}, {
-        "node": 1, "time": datetime.now()}]
-    pool = Pool(connections)
-    connection = pool.get_connection(timedelta(seconds=1))
-    assert connection == 0
-    pool.picker.next_node(connections)
-    connection = pool.get_connection(timedelta(seconds=0))
+    from datetime import datetime
 
-    assert connection == 1
-    pool.picker.next_node(connections)
-    connection = pool.get_connection(timedelta(seconds=1))
-    assert connection == 0
+    from bigchaindb_driver.connection import Connection
+    from bigchaindb_driver.pool import Pool
+
+    connections = [Connection(node_url=0)]
+    pool = Pool(connections)
+    for _ in range(10):
+        connection = pool.get_connection()
+        assert connection.node_url == 0
+
+    connections = [Connection(node_url=0), Connection(node_url=1),
+                   Connection(node_url=2)]
+    pool = Pool(connections)
+
+    for _ in range(10):
+        connection = pool.get_connection()
+        assert connection.node_url == 0
+
+    connections[0].backoff_time = datetime.utcnow()
+    for _ in range(10):
+        connection = pool.get_connection()
+        assert connection.node_url == 1
+
+    connections[1].backoff_time = datetime.utcnow()
+    for _ in range(10):
+        connection = pool.get_connection()
+        assert connection.node_url == 2
+
+    connections[2].backoff_time = datetime.utcnow()
+    for _ in range(10):
+        connection = pool.get_connection()
+        assert connection.node_url == 0

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -3,12 +3,16 @@ from requests.utils import default_headers
 
 def test_init_with_headers():
     from bigchaindb_driver.transport import Transport
-    from bigchaindb_driver.utils import _normalize_nodes
+    from bigchaindb_driver.utils import normalize_nodes
     headers = {'app_id': 'id'}
-    nodes = _normalize_nodes('node1', 'node2', headers=headers)
+    nodes = normalize_nodes('node1',
+                            {'endpoint': 'node2', 'headers': {'custom': 'c'}},
+                            headers=headers)
     transport = Transport(*nodes)
     expected_headers = default_headers()
     expected_headers.update(headers)
-    connections = transport.pool.connections
-    assert connections[0]["node"].session.headers == expected_headers
-    assert connections[1]["node"].session.headers == expected_headers
+
+    connections = transport.connection_pool.connections
+    assert connections[0].session.headers == expected_headers
+    assert connections[1].session.headers == {**expected_headers,
+                                              'custom': 'c'}

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,4 +1,13 @@
+import pytest
+
+from unittest.mock import patch
+
+from requests.exceptions import ConnectionError
 from requests.utils import default_headers
+
+from bigchaindb_driver.exceptions import TimeoutError
+from bigchaindb_driver.transport import Transport
+from bigchaindb_driver.utils import normalize_nodes
 
 
 def test_init_with_headers():
@@ -16,3 +25,68 @@ def test_init_with_headers():
     assert connections[0].session.headers == expected_headers
     assert connections[1].session.headers == {**expected_headers,
                                               'custom': 'c'}
+
+
+@patch('bigchaindb_driver.transport.time')
+@patch('bigchaindb_driver.transport.Connection._request')
+def test_timeout_after_first_node(request_mock, time_mock):
+
+    # simulate intermittent network failure on every attempt
+    request_mock.side_effect = ConnectionError
+
+    # simulate a second passing in between each pair of time() calls
+    time_mock.side_effect = [0, 1]
+    transport = Transport(*normalize_nodes('first_node', 'second_node'),
+                          timeout=1)
+
+    with pytest.raises(TimeoutError):
+        transport.forward_request('POST')
+
+    # the second node is not hit - timeout
+    assert len(request_mock.call_args_list) == 1
+    request_kwargs = request_mock.call_args_list[0][1]
+    assert 'first_node' in request_kwargs['url']
+    # timeout is propagated to the HTTP request
+    assert request_kwargs['timeout'] == 1
+
+
+@patch('bigchaindb_driver.transport.time')
+@patch('bigchaindb_driver.transport.Connection._request')
+def test_timeout_after_second_node(request_mock, time_mock):
+
+    request_mock.side_effect = ConnectionError
+
+    time_mock.side_effect = [0, 1, 1, 2]
+    transport = Transport(*normalize_nodes('first_node', 'second_node'),
+                          timeout=2)
+
+    with pytest.raises(TimeoutError):
+        transport.forward_request('POST')
+
+    # timeout=2 now so we manage to hit the second node
+    assert len(request_mock.call_args_list) == 2
+    first_request_kwargs = request_mock.call_args_list[0][1]
+    second_request_kwargs = request_mock.call_args_list[1][1]
+    assert 'first_node' in first_request_kwargs['url']
+    assert first_request_kwargs['timeout'] == 2
+    assert 'second_node' in second_request_kwargs['url']
+    assert second_request_kwargs['timeout'] == 1
+
+
+@patch('bigchaindb_driver.transport.time')
+@patch('bigchaindb_driver.transport.Connection._request')
+def test_timeout_during_request(request_mock, time_mock):
+
+    request_mock.side_effect = TimeoutError
+
+    time_mock.side_effect = [0, 1]
+    transport = Transport(*normalize_nodes('first_node', 'second_node'),
+                          timeout=100)
+
+    with pytest.raises(TimeoutError):
+        transport.forward_request('POST')
+
+    assert len(request_mock.call_args_list) == 1
+    request_kwargs = request_mock.call_args_list[0][1]
+    assert 'first_node' in request_kwargs['url']
+    assert request_kwargs['timeout'] == 100

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,8 +14,8 @@ from pytest import mark
      ({'endpoint': 'https://node.xyz:443/path', 'headers': {}},)),
 ))
 def test_single_node_normalization(node, normalized_node):
-    from bigchaindb_driver.utils import _normalize_nodes, _normalize_url
-    assert _normalize_nodes(_normalize_url(node)) == normalized_node
+    from bigchaindb_driver.utils import normalize_nodes, normalize_url
+    assert normalize_nodes(normalize_url(node)) == normalized_node
 
 
 @mark.parametrize('nodes,normalized_nodes', (
@@ -29,5 +29,5 @@ def test_single_node_normalization(node, normalized_node):
        'headers': {}})),
 ))
 def test_iterable_of_nodes_normalization(nodes, normalized_nodes):
-    from bigchaindb_driver.utils import _normalize_nodes
-    assert _normalize_nodes(*nodes) == normalized_nodes
+    from bigchaindb_driver.utils import normalize_nodes
+    assert normalize_nodes(*nodes) == normalized_nodes


### PR DESCRIPTION
Solution: Improve the implementation:
- remove busy wait;
- only retry connection errors;
- simplify the code;
- make custom headers overwrite common headers, not vice versa;
- add some more tests;
- remove obsolete await_transaction;
- make the linter pass.