### PR TITLE
Change docs license to CC-BY-4

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -6,4 +6,4 @@ For the licenses on all other BigchainDB-related code, see the license file in t
 
 # Documentation Licenses
 
-The official BigchainDB documentation, _except for the short code snippets embedded within it_, is licensed under a Creative Commons Attribution-ShareAlike 4.0 International license, the full text of which can be found at [http://creativecommons.org/licenses/by-sa/4.0/legalcode](http://creativecommons.org/licenses/by-sa/4.0/legalcode).
+The official BigchainDB documentation, _except for the short code snippets embedded within it_, is licensed under a Creative Commons Attribution 4.0 International license, the full text of which can be found at [http://creativecommons.org/licenses/by/4.0/legalcode](http://creativecommons.org/licenses/by/4.0/legalcode).


### PR DESCRIPTION
The docs license was CC-BY-SA-4. This change was in preparation for the HL application.
