### PR TITLE
Problem: No comments re/ licensing in source files

### DIFF
--- a/.ci/travis-after-success.sh
+++ b/.ci/travis-after-success.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.ci/travis-before-install.sh
+++ b/.ci/travis-before-install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 if [[ "${TOXENV}" == "py35" || "${TOXENV}" == "py36" ]]; then
   sudo apt-get update

--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.ci/travis_script.sh
+++ b/.ci/travis_script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     sha: v1.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 language: python
 python:
   - 3.5

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 =======
 Credits
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Changelog
 =========
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Contributor Code of Conduct
 
 As contributors and maintainers of this project, and in the interest of

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. highlight:: shell
 
 ============

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. image:: media/repo-banner@2x.png
 
 .. image:: https://badges.gitter.im/bigchaindb/bigchaindb-driver.svg

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Our Release Process
 
 ## Notes

--- a/bigchaindb_driver/__init__.py
+++ b/bigchaindb_driver/__init__.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from .driver import BigchainDB   # noqa
 
 

--- a/bigchaindb_driver/common/__init__.py
+++ b/bigchaindb_driver/common/__init__.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ###############################################################################
 # DO NOT CHANGE THIS FILE.                                                    #
 #                                                                             #

--- a/bigchaindb_driver/common/crypto.py
+++ b/bigchaindb_driver/common/crypto.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ###############################################################################
 # DO NOT CHANGE THIS FILE.                                                    #
 #                                                                             #

--- a/bigchaindb_driver/common/exceptions.py
+++ b/bigchaindb_driver/common/exceptions.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ###############################################################################
 # DO NOT CHANGE THIS FILE.                                                    #
 #                                                                             #

--- a/bigchaindb_driver/common/transaction.py
+++ b/bigchaindb_driver/common/transaction.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ###############################################################################
 # DO NOT CHANGE THIS FILE.                                                    #
 #                                                                             #

--- a/bigchaindb_driver/common/utils.py
+++ b/bigchaindb_driver/common/utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ###############################################################################
 # DO NOT CHANGE THIS FILE.                                                    #
 #                                                                             #

--- a/bigchaindb_driver/connection.py
+++ b/bigchaindb_driver/connection.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import time
 
 from collections import namedtuple

--- a/bigchaindb_driver/crypto.py
+++ b/bigchaindb_driver/crypto.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from collections import namedtuple
 
 from cryptoconditions import crypto

--- a/bigchaindb_driver/driver.py
+++ b/bigchaindb_driver/driver.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from .transport import Transport
 from .offchain import prepare_transaction, fulfill_transaction
 from .utils import normalize_nodes

--- a/bigchaindb_driver/exceptions.py
+++ b/bigchaindb_driver/exceptions.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Exceptions used by :mod:`bigchaindb_driver`."""
 
 

--- a/bigchaindb_driver/offchain.py
+++ b/bigchaindb_driver/offchain.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Module for operations that can be performed "offchain", meaning without
 a connection to one or more  BigchainDB federation nodes.
 

--- a/bigchaindb_driver/pool.py
+++ b/bigchaindb_driver/pool.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
 

--- a/bigchaindb_driver/transport.py
+++ b/bigchaindb_driver/transport.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from time import time
 
 from requests.exceptions import ConnectionError

--- a/bigchaindb_driver/utils.py
+++ b/bigchaindb_driver/utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Set of utilities to support various functionalities of the driver.
 
 Attributes:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 codecov:
   branch: master
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 version: '2.1'
 
 services:

--- a/docs/aboutthedocs.rst
+++ b/docs/aboutthedocs.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 About this Documentation
 ========================
 

--- a/docs/advanced-installation.rst
+++ b/docs/advanced-installation.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Advanced Installation Options
 =============================
 

--- a/docs/advanced-usage.rst
+++ b/docs/advanced-usage.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _advanced-usage:
 
 =======================

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,1 +1,6 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. include:: ../AUTHORS.rst

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,6 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. include:: ../CHANGELOG.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import sys
 import os
 import datetime

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _connect:
 
 =================================

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,1 +1,6 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. include:: ../CONTRIBUTING.rst

--- a/docs/handcraft.rst
+++ b/docs/handcraft.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 #########################
 Handcrafting Transactions
 #########################

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. bigchaindb_driver documentation master file, created by
    sphinx-quickstart on Tue Jul  9 22:26:36 2013.
    You can adapt this file completely to your liking, but it should at least

--- a/docs/libref.rst
+++ b/docs/libref.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Library Reference
 =================
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 =========================
 Quickstart / Installation
 =========================

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 =========
 Upgrading
 =========

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _basic-usage:
 
 ====================

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
 
 from setuptools import setup, find_packages
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import json
 from base64 import b64encode
 from collections import namedtuple

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from pytest import mark
 from requests.utils import default_headers
 from responses import RequestsMock

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,3 +1,8 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+
 def test_generate_keypair():
     from bigchaindb_driver.crypto import CryptoKeypair, generate_keypair
     keypair = generate_keypair()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 import json
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,8 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+
 class TestTransportError:
 
     def test_status_code_property(self):

--- a/tests/test_offchain.py
+++ b/tests/test_offchain.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import rapidjson
 from cryptoconditions import Fulfillment
 from sha3 import sha3_256

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,3 +1,8 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+
 def test_get_connection():
     from datetime import datetime
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 from unittest.mock import patch

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from pytest import mark
 
 

--- a/travis_pypi_setup.py
+++ b/travis_pypi_setup.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Update encrypted deploy password in Travis config file
 """
 


### PR DESCRIPTION
Solution: Add license info comments to all source files

Notes:
- I added comments about license info to all source files using the [add-spdx script](https://github.com/bigchaindb/BEPs/blob/master/tools/add-spdx).
- I removed some of the auto-added comments, from:
  - `LICENSES.md`
  - `.github/ISSUE_TEMPLATE.md`
  - `.github/PULL_REQUEST_TEMPLATE.md`
- I built the docs locally without problems, and they looked okay in my browser.
- I ran `make test` locally and all 96 tests passed.
- When I did `git commit`, the pre-commit checks failed on some Flake8 errors, so I fixed those.