### PR TITLE
Pin cryptoconditions==0.7.2 in setup.py, for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('CHANGELOG.rst') as changelog_file:
 
 install_requires = [
     'requests>=2.11.0',
-    'cryptoconditions~=0.7.2',
+    'cryptoconditions==0.7.2',
     'pysha3~=1.0.2',
     'python-rapidjson==0.6.0',
     'python-rapidjson-schema==0.1.1',


### PR DESCRIPTION
This is to get ReadTheDocs working, or at least partly working. To understand the reasoning, see https://github.com/bigchaindb/bigchaindb/pull/2512
