### PR TITLE
Fixed 'Handcrafting Transactions' & 'Quickstart' docs

### DIFF
--- a/docs/handcraft.rst
+++ b/docs/handcraft.rst
@@ -273,13 +273,9 @@ As for the details:
 
 .. ipython::
 
-    In [0]: def b58(key):
-       ...:     # convert key to a base58 string
-       ...:     return base58.b58encode(key).decode()
-
     In [0]: condition_details = {
        ...:     'type': ed25519.TYPE_NAME,
-       ...:     'public_key': b58(ed25519.public_key),
+       ...:     'public_key': base58.b58encode(ed25519.public_key).decode()
        ...: }
 
 We can now easily assemble the ``dict`` for the output:
@@ -308,7 +304,7 @@ Let's recap and set the ``outputs`` key with our self-constructed condition:
        ...:     'condition': {
        ...:         'details': {
        ...:             'type': ed25519.TYPE_NAME,
-       ...:             'public_key': b58(ed25519.public_key),
+       ...:             'public_key': base58.b58encode(ed25519.public_key).decode(),
        ...:         },
        ...:         'uri': ed25519.condition_uri,
        ...:     },
@@ -463,7 +459,7 @@ Let's recap how we've put all the code together to generate the above payload:
         'condition': {
             'details': {
                 'type': ed25519.TYPE_NAME,
-                'public_key': b58(ed25519.public_key),
+                'public_key': base58.b58encode(ed25519.public_key).decode(),
             },
             'uri': ed25519.condition_uri,
         },
@@ -612,7 +608,7 @@ Handcrafting a ``CREATE`` transaction can be done as follows:
         'condition': {
             'details': {
                 'type': ed25519.TYPE_NAME,
-                'public_key': b58(ed25519.public_key),
+                'public_key': base58.b58encode(ed25519.public_key).decode(),
             },
             'uri': ed25519.condition_uri,
         },
@@ -820,7 +816,7 @@ outputs
        ...:     'condition': {
        ...:         'details': {
        ...:             'type': ed25519.TYPE_NAME,
-       ...:             'public_key': b58(ed25519.public_key),
+       ...:             'public_key': base58.b58encode(ed25519.public_key).decode(),
        ...:         },
        ...:         'uri': ed25519.condition_uri,
        ...:     },
@@ -936,7 +932,7 @@ Let's recap how we got here:
         'condition': {
             'details': {
                 'type': ed25519.TYPE_NAME,
-                'public_key': b58(ed25519.public_key),
+                'public_key': base58.b58encode(ed25519.public_key).decode(),
             },
             'uri': ed25519.condition_uri,
         },
@@ -1068,7 +1064,7 @@ In a nutshell
         'condition': {
             'details': {
                 'type': ed25519.TYPE_NAME,
-                'public_key': b58(ed25519.public_key),
+                'public_key': base58.b58encode(ed25519.public_key).decode(),
             },
             'uri': ed25519.condition_uri,
         },
@@ -1193,7 +1189,7 @@ Handcrafting the ``CREATE`` transaction for our :ref:`bicycle sharing example
     # CRYPTO-CONDITIONS: construct an unsigned fulfillment dictionary
     unsigned_fulfillment_dict = {
         'type': ed25519.TYPE_NAME,
-        'public_key': b58(ed25519.public_key),
+        'public_key': base58.b58encode(ed25519.public_key).decode(),
     }
 
     output = {
@@ -1304,12 +1300,12 @@ to Bob:
     # CRYPTO-CONDITIONS: get the unsigned fulfillment dictionary (details)
     bob_unsigned_fulfillment_dict = {
         'type': bob_ed25519.TYPE_NAME,
-        'public_key': b58(bob_ed25519.public_key),
+        'public_key': base58.b58encode(bob_ed25519.public_key).decode(),
     }
 
     carly_unsigned_fulfillment_dict = {
         'type': carly_ed25519.TYPE_NAME,
-        'public_key': b58(carly_ed25519.public_key),
+        'public_key': base58.b58encode(carly_ed25519.public_key).decode(),
     }
 
     bob_output = {
@@ -1558,7 +1554,7 @@ Generate the output condition:
     In [0]: condition_details = {
        ...:     'subconditions': [
        ...:         {'type': s['body'].TYPE_NAME,
-       ...:          'public_key': b58(s['body'].public_key)}
+       ...:          'public_key': base58.b58encode(s['body'].public_key).decode()}
        ...:         for s in threshold_sha256.subconditions
        ...:         if (s['type'] == 'fulfillment' and
        ...:             s['body'].TYPE_NAME == 'ed25519-sha-256')
@@ -1677,7 +1673,7 @@ The transfer to Carol:
 
     In [0]: unsigned_fulfillments_dict = {
        ...:     'type': carol_ed25519.TYPE_NAME,
-       ...:     'public_key': b58(carol_ed25519.public_key),
+       ...:     'public_key': base58.b58encode(carol_ed25519.public_key).decode(),
        ...: }
 
     In [0]: condition_uri = carol_ed25519.condition.serialize_uri()
@@ -1824,7 +1820,7 @@ Handcrafting the ``'CREATE'`` transaction
     condition_details = {
         'subconditions': [
             {'type': s['body'].TYPE_NAME,
-             'public_key': b58(s['body'].public_key)}
+             'public_key': base58.b58encode(s['body'].public_key).decode()}
             for s in threshold_sha256.subconditions
             if (s['type'] == 'fulfillment' and
                 s['body'].TYPE_NAME == 'ed25519-sha-256')
@@ -1925,7 +1921,7 @@ Handcrafting the ``'TRANSFER'`` transaction
 
     unsigned_fulfillments_dict = {
         'type': carol_ed25519.TYPE_NAME,
-        'public_key': b58(carol_ed25519.public_key),
+        'public_key': base58.b58encode(carol_ed25519.public_key).decode(),
     }
 
     condition_uri = carol_ed25519.condition.serialize_uri()
@@ -2081,7 +2077,7 @@ Handcrafting the ``'CREATE'`` transaction
     condition_details = {
         'subconditions': [
             {'type': s['body'].TYPE_NAME,
-             'public_key': b58(s['body'].public_key)}
+             'public_key': base58.b58encode(s['body'].public_key).decode()}
             for s in threshold_sha256.subconditions
             if (s['type'] == 'fulfillment' and
                 s['body'].TYPE_NAME == 'ed25519-sha-256')
@@ -2191,7 +2187,7 @@ Handcrafting the ``'TRANSFER'`` transaction
         'condition': {
             'details': {
                 'type': carol_ed25519.TYPE_NAME,
-                'public_key': b58(carol_ed25519.public_key),
+                'public_key': base58.b58encode(carol_ed25519.public_key).decode(),
             },
             'uri': condition_uri,
         },

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,7 +9,9 @@ Quickstart / Installation
 
 .. warning::
 
-	The instructions below were tested on Ubuntu 16.04 LTS. They should also work on other Linux distributions and on macOS. The driver might work on Windows as well, but we do not guarantee it. We recommend to set up (e.g. via Docker For Windows) an Ubuntu VM there.
+   The instructions below were tested on Ubuntu 16.04 LTS.
+   They should also work on other Linux distributions and on macOS.
+   For other operating systems, we recommend using an Ubuntu virtual machine (VM).
 
 The BigchainDB Python Driver depends on:
 
@@ -79,8 +81,7 @@ You can check your version of ``pip`` using:
 
 ``pip`` was at version 9.0.0 as of November 2016.
 If you need to upgrade your version of ``pip``,
-then see `the pip documentation <https://pip.pypa.io/en/stable/installing/>`_
-or our page about that in the `BigchainDB Server docs <https://docs.bigchaindb.com/projects/server/en/latest/appendices/install-latest-pip.html>`_.
+then see `the pip documentation <https://pip.pypa.io/en/stable/installing/>`_.
 
 
 Dependency 3: setuptools
@@ -112,14 +113,6 @@ On Ubuntu 14.04 and 16.04, this works:
     $ sudo apt-get update
 
     $ sudo apt-get install python3-dev libssl-dev libffi-dev
-
-On Fedora 23 and 24, this works:
-
-.. code-block:: bash
-
-    $ sudo dnf update
-
-    $ sudo dnf install python-devel openssl-devel libffi-devel
 
 For other operating systems, please refer to `the cryptography installation guide <https://cryptography.io/en/latest/installation/#installation>`_.
 


### PR DESCRIPTION
It seems you can no longer define a function using IPython inside docs. That used to work. It stopped working, and it seems that's what caused the 'Handcrafting Transactions' page to stop building lately.

I also updated and simplified the 'Quickstart' page in the docs.
