### PR TITLE
Let python-rapidjson~=0.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'requests>=2.11.0',
     'cryptoconditions==0.8.0',
     'pysha3~=1.0.2',
-    'python-rapidjson==0.6.0',
+    'python-rapidjson~=0.6.0',
     'python-rapidjson-schema==0.1.1',
 ]
 


### PR DESCRIPTION
to be consistent with bigchaindb
