### PR TITLE
Remove --process-dependency-links everywhere

### DIFF
--- a/compose/bigchaindb_driver/Dockerfile
+++ b/compose/bigchaindb_driver/Dockerfile
@@ -9,4 +9,4 @@ RUN pip install --upgrade pip
 
 COPY . /usr/src/app/
 
-RUN pip install --no-cache-dir --process-dependency-links -e .[dev]
+RUN pip install --no-cache-dir -e .[dev]

--- a/docs/advanced-installation.rst
+++ b/docs/advanced-installation.rst
@@ -28,18 +28,5 @@ Once you have a copy of the source code, you can install it by going to the dire
 
     python setup.py install
 
-
-Installing latest master with pip
----------------------------------
-
-To work with the latest BigchainDB (server) master branch:
-
-.. code-block:: bash
-
-    $ pip install --process-dependency-links git+https://github.com/bigchaindb/bigchaindb-driver.git
-
-Then connect to some BigchainDB node which is running BigchainDB server ``master``.
-
-
 .. _Github repo: https://github.com/bigchaindb/bigchaindb-driver
 .. _tarball: https://github.com/bigchaindb/bigchaindb-driver/tarball/master

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,6 @@ setenv =
     BIGCHAINDB_DATABASE_BACKEND=mongodb
 deps =
     {[base]deps}
-install_command = pip install {opts} {packages} --process-dependency-links .[test]
+install_command = pip install {opts} {packages} .[test]
 commands =
     py.test -v -n auto --cov=bigchaindb_driver --basetemp={envtmpdir}


### PR DESCRIPTION
The `--process-dependency-links` option is no longer supported by `pip` as of version 19.0. See https://pip.pypa.io/en/stable/news/#id4 
